### PR TITLE
fix: pass TORALE_NOAUTH environment variable to docker compose

### DIFF
--- a/justfile
+++ b/justfile
@@ -37,9 +37,7 @@ dev-all: build
 # Start all services + frontend in no-auth mode
 dev-all-noauth: build
     #!/usr/bin/env bash
-    export TORALE_NOAUTH=1
-    export VITE_TORALE_NOAUTH=1
-    docker compose up -d
+    TORALE_NOAUTH=1 docker compose up -d
     cd frontend && VITE_TORALE_NOAUTH=1 npm run dev
 
 # View logs for all services


### PR DESCRIPTION
## Problem
The `just dev-all-noauth` recipe was broken because the `TORALE_NOAUTH` environment variable was being exported in the bash script scope but wasn't being passed to docker compose.

This resulted in:
- Backend containers running with `TORALE_NOAUTH=0` (auth enabled)
- Frontend running with `VITE_TORALE_NOAUTH=1` (no-auth mode)
- Mismatch causing 401 Unauthorized errors in the browser

## Solution
Changed the justfile recipe to pass the environment variable directly to the docker compose command:

```bash
# Before (broken)
export TORALE_NOAUTH=1
docker compose up -d

# After (fixed)
TORALE_NOAUTH=1 docker compose up -d
```

## Testing
Verified that:
- Backend API starts with `TORALE_NOAUTH=1` 
- Test user is created automatically
- API accepts requests without authentication
- Worker connects to Temporal successfully

## Changes
- Modified `justfile` line 40-43 to use inline environment variable syntax