### PR TITLE
feat: add configurable email for no-auth mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,4 +48,4 @@ GCP_REGION=us-central1
 # Set to 1 to disable authentication in local development
 TORALE_NOAUTH=
 # Email to use for test user in no-auth mode (defaults to test@example.com)
-NOVU_NOAUTH_EMAIL=test@example.com
+TORALE_NOAUTH_EMAIL=test@example.com

--- a/backend/src/torale/api/clerk_auth.py
+++ b/backend/src/torale/api/clerk_auth.py
@@ -282,7 +282,7 @@ async def get_current_user_or_test_user(
         # Return a test user with a fixed UUID
         return ClerkUser(
             clerk_user_id="test_user_noauth",
-            email=settings.novu_noauth_email,
+            email=settings.torale_noauth_email,
             email_verified=True,
             db_user_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
         )

--- a/backend/src/torale/api/main.py
+++ b/backend/src/torale/api/main.py
@@ -26,9 +26,9 @@ async def lifespan(app: FastAPI):
             VALUES ('00000000-0000-0000-0000-000000000001', 'test_user_noauth', $1, true)
             ON CONFLICT (clerk_user_id) DO UPDATE SET email = EXCLUDED.email
         """,
-            settings.novu_noauth_email,
+            settings.torale_noauth_email,
         )
-        print(f"✓ Test user ready ({settings.novu_noauth_email})")
+        print(f"✓ Test user ready ({settings.torale_noauth_email})")
 
     yield
     await db.disconnect()

--- a/backend/src/torale/core/config.py
+++ b/backend/src/torale/core/config.py
@@ -40,7 +40,7 @@ class Settings(BaseSettings):
 
     # Development/testing mode - disable authentication
     torale_noauth: bool = False
-    novu_noauth_email: str = "test@example.com"
+    torale_noauth_email: str = "test@example.com"
 
     # Platform capacity limit for beta
     max_users: int = 100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
       - NOVU_VERIFICATION_WORKFLOW_ID=${NOVU_VERIFICATION_WORKFLOW_ID:-torale-email-verification}
       - NOVU_API_URL=${NOVU_API_URL:-https://eu.api.novu.co}
       - TORALE_NOAUTH=${TORALE_NOAUTH:-0}
-      - NOVU_NOAUTH_EMAIL=${NOVU_NOAUTH_EMAIL:-test@example.com}
+      - TORALE_NOAUTH_EMAIL=${TORALE_NOAUTH_EMAIL:-test@example.com}
       - MAX_USERS=${MAX_USERS:-100}
     depends_on:
       init-migrations:
@@ -139,7 +139,7 @@ services:
       - NOVU_VERIFICATION_WORKFLOW_ID=${NOVU_VERIFICATION_WORKFLOW_ID:-torale-email-verification}
       - NOVU_API_URL=${NOVU_API_URL:-https://eu.api.novu.co}
       - TORALE_NOAUTH=${TORALE_NOAUTH:-0}
-      - NOVU_NOAUTH_EMAIL=${NOVU_NOAUTH_EMAIL:-test@example.com}
+      - TORALE_NOAUTH_EMAIL=${TORALE_NOAUTH_EMAIL:-test@example.com}
     depends_on:
       - postgres
       - temporal


### PR DESCRIPTION
## Summary
Adds support for configurable test user email in no-auth development mode via the `NOVU_NOAUTH_EMAIL` environment variable.

## Problem
The no-auth mode used a hardcoded `test@example.com` email for the test user, making it inconvenient for developers who want to use their own email address for testing notifications.

## Solution
Added `NOVU_NOAUTH_EMAIL` environment variable that:
- Configures the test user email in no-auth mode
- Defaults to `test@example.com` for backward compatibility
- Updates the test user email on startup if changed

## Changes
- **backend/src/torale/core/config.py** - Added `novu_noauth_email` setting
- **backend/src/torale/api/clerk_auth.py** - Use configurable email instead of hardcoded value
- **backend/src/torale/api/main.py** - Update test user creation with parameterized query and `ON CONFLICT DO UPDATE`
- **docker-compose.yml** - Pass `NOVU_NOAUTH_EMAIL` to API and Workers containers
- **.env.example** - Document the new environment variable

## Testing
Verified that:
- Test user email is configurable via `NOVU_NOAUTH_EMAIL` env var
- Email defaults to `test@example.com` if not set
- Test user email updates on restart if changed
- Backward compatible with existing setups

## Notes
- Webhooks already support no-auth mode (no Novu dependency required)
- Email notifications require `NOVU_SECRET_KEY` but gracefully skip if not configured
- Users can enable webhooks by setting `notification_channels: ["webhook"]` on tasks

## Related
Addresses question about webhook support in no-auth mode from development session.