### PR TITLE
fix: disable Cloudflare proxy for ingress DNS records via external-dns

### DIFF
--- a/helm/torale/values.yaml
+++ b/helm/torale/values.yaml
@@ -239,6 +239,7 @@ ingress:
     kubernetes.io/ingress.global-static-ip-name: "clusterkit-ingress-ip"
     networking.gke.io/managed-certificates: "torale-cert"
     networking.gke.io/v1beta1.FrontendConfig: "ssl-redirect"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
 
   # SSL/TLS configuration
   tls:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add `external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"` to ingress annotations to disable Cloudflare proxying for ExternalDNS-managed records.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f763335e62159a8983d6ab835034748ebedef8f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->