### PR TITLE
fix: Landing page capacity display using wrong API URL

### DIFF
--- a/frontend/src/components/Landing.tsx
+++ b/frontend/src/components/Landing.tsx
@@ -99,8 +99,8 @@ export default function Landing() {
     // Fetch available user slots
     const fetchCapacity = async () => {
       try {
-        // Use relative URL - Vite proxy will handle it in dev, production uses full URL
-        const response = await fetch('/public/stats');
+        const apiUrl = window.CONFIG?.apiUrl || import.meta.env.VITE_API_BASE_URL;
+        const response = await fetch(`${apiUrl}/public/stats`);
         if (response.ok) {
           const data = await response.json();
           if (typeof data?.capacity?.available_slots === "number") {


### PR DESCRIPTION
## Problem
The pricing section on the Landing page showed 'Free while in beta' instead of 'Free for X remaining users' because it was using a relative URL `/public/stats` that only works in dev (Vite proxy).

In production, the relative URL fetched from the frontend nginx server, returning HTML instead of JSON, causing:
```
SyntaxError: Unexpected token '<', "<\!doctype "... is not valid JSON
```

## Solution
Changed Landing.tsx to use the same pattern as CapacityGate.tsx:
```typescript
const apiUrl = window.CONFIG?.apiUrl || import.meta.env.VITE_API_BASE_URL;
const response = await fetch(`${apiUrl}/public/stats`);
```

This uses the runtime config in production and falls back to env vars in dev.

## Testing
- Built successfully ✅
- No TypeScript errors ✅
- Matches the working CapacityGate.tsx pattern ✅