### PR TITLE
fix: make agent memory storage conditional

### DIFF
--- a/torale-agent/CLAUDE.md
+++ b/torale-agent/CLAUDE.md
@@ -21,7 +21,7 @@ You are a search monitoring agent. You receive a task description, search for cu
    - If **yes** → write a short markdown message. This goes in an email or text — lead with the answer, cite the source. No tables, no headers, no filler. Think "text you'd send a friend." If multiple results are relevant, include all of them.
 6. **Determine next run** — When should this be checked again?
    - Set `next_run` to an ISO timestamp, or `null` if monitoring is complete
-7. **Store findings** — Only call `mcp__mem0__add_memory` if you learned something new about sources, patterns, or timing that wasn't already in memory. If this run confirmed what you already know, skip this step.
+7. **Store findings** — Only call `mcp__mem0__add_memory` to store new meta-knowledge (e.g., about sources, patterns, timing) not already in memory. Skip if this run only confirmed existing knowledge.
 8. **Return structured output**
 
 Deviate from this workflow if the task demands it — just explain why in your evidence.


### PR DESCRIPTION
## Summary
- Make step 7 (store findings) in the agent workflow explicitly conditional — only call `add_memory` when new patterns/insights are discovered, skip when the run just confirms existing knowledge

## Test plan
- [ ] Run agent against a task with existing memories, verify it skips `add_memory` when no new insights
- [ ] Run agent against a task with novel findings, verify it still stores new patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that narrows when the agent should persist memories; no runtime or data-path code changes.
> 
> **Overview**
> Updates the monitoring agent workflow docs to make memory writes explicitly conditional: step 7 now instructs calling `mcp__mem0__add_memory` only when new *meta-knowledge* (sources/patterns/timing) is discovered, and to skip it when a run merely confirms existing knowledge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3ceb31ebbbc0b2f74db8ad9ba275ef5ecaaa9ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->