### PR TITLE
feat: add admin execute task endpoint and Run Now button

### DIFF
--- a/frontend/src/components/admin/TaskDetailPanel.tsx
+++ b/frontend/src/components/admin/TaskDetailPanel.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
 import { api } from '@/lib/api'
-import { Loader2, Clock, Zap, AlertTriangle, FileText } from 'lucide-react'
+import { Loader2, Clock, Zap, AlertTriangle, FileText, Play } from 'lucide-react'
 import { SectionLabel, StatusBadge } from '@/components/torale'
+import { toast } from 'sonner'
 import { stateToVariant } from './types'
 import type { TaskData } from './types'
 
@@ -47,6 +48,20 @@ export function TaskDetailPanel({ task }: TaskDetailPanelProps) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [retryCount, setRetryCount] = useState(0)
+  const [isExecuting, setIsExecuting] = useState(false)
+
+  const handleExecute = async () => {
+    setIsExecuting(true)
+    try {
+      await api.adminExecuteTask(task.id)
+      toast.success('Execution started')
+      setRetryCount((c) => c + 1) // Refresh executions
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to execute task')
+    } finally {
+      setIsExecuting(false)
+    }
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -72,6 +87,23 @@ export function TaskDetailPanel({ task }: TaskDetailPanelProps) {
 
   return (
     <div className="bg-zinc-50 border-t border-zinc-200 p-4 space-y-4">
+      {/* Actions */}
+      <div className="flex items-center gap-2">
+        <SectionLabel>Actions</SectionLabel>
+        <button
+          onClick={handleExecute}
+          disabled={isExecuting || task.state === 'completed'}
+          className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-zinc-900 text-white text-xs font-mono hover:bg-[hsl(10,90%,55%)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isExecuting ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <Play className="h-3 w-3" />
+          )}
+          Run Now
+        </button>
+      </div>
+
       {/* Metadata */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
         <div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -234,6 +234,18 @@ class ApiClient {
     return this.handleResponse(response)
   }
 
+  async adminExecuteTask(
+    taskId: string,
+    suppressNotifications: boolean = true
+  ): Promise<{ id: string; task_id: string; status: string; message: string }> {
+    const url = `${this.baseUrl}/admin/tasks/${taskId}/execute?suppress_notifications=${suppressNotifications}`
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: await this.getAuthHeaders(),
+    })
+    return this.handleResponse(response)
+  }
+
   // Waitlist endpoints
   async getWaitlist(statusFilter?: string): Promise<any> {
     const url = statusFilter


### PR DESCRIPTION
## Summary

- Add `POST /admin/tasks/{task_id}/execute` endpoint for admins to manually trigger any user's task
- Add "Run Now" button in admin TaskDetailPanel component
- Notifications suppressed by default for admin executions (debugging use case)

## Changes

| File | Change |
|------|--------|
| `backend/src/torale/api/routers/admin.py` | New endpoint with background task execution |
| `frontend/src/lib/api.ts` | New `adminExecuteTask` method |
| `frontend/src/components/admin/TaskDetailPanel.tsx` | "Run Now" button with loading state |

## Test plan

- [ ] Run `just dev-noauth` to start local dev
- [ ] Navigate to admin console `/admin`
- [ ] Go to Tasks tab and expand a task
- [ ] Click "Run Now" button
- [ ] Verify execution appears in execution history after refresh
- [ ] Verify button is disabled for completed tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)