### PR TITLE
refactor: use FastAPI BackgroundTasks for task execution

### DIFF
--- a/backend/src/torale/api/routers/admin.py
+++ b/backend/src/torale/api/routers/admin.py
@@ -7,16 +7,16 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from torale.access import ClerkUser, clerk_client, require_admin
+from torale.api.routers.tasks import start_task_execution
 from torale.core.config import settings
 from torale.core.database import Database, get_db
 from torale.core.database_alchemy import get_async_session
-from torale.scheduler.job import execute_task_job_manual
 from torale.scheduler.scheduler import get_scheduler
 from torale.tasks import TaskState
 from torale.tasks.service import TaskService
@@ -24,19 +24,6 @@ from torale.tasks.service import TaskService
 router = APIRouter(prefix="/admin", tags=["admin"], include_in_schema=False)
 
 logger = logging.getLogger(__name__)
-
-# Module-level set to prevent GC of background tasks
-_background_tasks: set[asyncio.Task] = set()
-
-
-def _handle_background_task_result(task: asyncio.Task) -> None:
-    """Log unhandled exceptions from manual task executions."""
-    _background_tasks.discard(task)
-    if task.cancelled():
-        return
-    exc = task.exception()
-    if exc:
-        logger.error(f"Background task execution failed: {exc}", exc_info=exc)
 
 
 # Request models for role management
@@ -993,6 +980,7 @@ async def delete_waitlist_entry(
 @router.post("/tasks/{task_id}/execute")
 async def admin_execute_task(
     task_id: UUID,
+    background_tasks: BackgroundTasks,
     suppress_notifications: bool = Query(default=True),
     admin: ClerkUser = Depends(require_admin),
     db: Database = Depends(get_db),
@@ -1026,32 +1014,16 @@ async def admin_execute_task(
             detail="Task not found",
         )
 
-    # Create execution record
-    execution_query = """
-        INSERT INTO task_executions (task_id, status)
-        VALUES ($1, $2)
-        RETURNING id, task_id, status, started_at, completed_at, result, error_message, created_at
-    """
-    execution_row = await db.fetch_one(execution_query, task_id, "pending")
-
-    if not execution_row:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Failed to create execution record",
-        )
-
-    # Run agent execution in background (prevent GC via module-level set)
-    bg_task = asyncio.create_task(
-        execute_task_job_manual(
-            task_id=str(task_id),
-            execution_id=str(execution_row["id"]),
-            user_id=str(task_row["user_id"]),
-            task_name=task_row["name"],
-            suppress_notifications=suppress_notifications,
-        )
+    # Reuse existing helper for execution creation + background task scheduling
+    execution_row = await start_task_execution(
+        task_id=str(task_id),
+        task_name=task_row["name"],
+        user_id=str(task_row["user_id"]),
+        db=db,
+        background_tasks=background_tasks,
+        suppress_notifications=suppress_notifications,
     )
-    _background_tasks.add(bg_task)
-    bg_task.add_done_callback(_handle_background_task_result)
+
     logger.info(f"Admin {admin.email} started execution {execution_row['id']} for task {task_id}")
 
     return {


### PR DESCRIPTION
## Summary

- Replace manual `asyncio.create_task()` + module-level set pattern with FastAPI's built-in `BackgroundTasks`
- Add `_safe_execute_task_job_manual` wrapper to ensure exceptions are logged (BackgroundTasks silently swallows exceptions)
- Extract `start_task_execution` helper and reuse in admin.py to eliminate code duplication (~25 lines)
- Remove redundant `_handle_background_task_result` callbacks and `_background_tasks` sets

## Test plan

- [x] `just lint` passes
- [x] `just test` passes (174 tests)
- [ ] Manual: Admin panel → Task detail → "Run Now" → verify execution starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)