### PR TITLE
fix: force toast theme to light mode, remove unused next-themes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,7 +44,6 @@
         "input-otp": "^1.4.2",
         "lucide-react": "^0.441.0",
         "motion": "^12.23.25",
-        "next-themes": "^0.4.6",
         "picomatch": "^4.0.3",
         "react": "^18.3.1",
         "react-day-picker": "^9.11.1",
@@ -6303,16 +6302,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/next-themes": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
-      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
-      }
     },
     "node_modules/node-releases": {
       "version": "2.0.27",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,6 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^0.441.0",
     "motion": "^12.23.25",
-    "next-themes": "^0.4.6",
     "picomatch": "^4.0.3",
     "react": "^18.3.1",
     "react-day-picker": "^9.11.1",

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { useTheme } from "next-themes";
 import { Toaster as Sonner, ToasterProps } from "sonner";
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
-
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme="light"
       className="toaster group"
       position="bottom-right"
       expand={false}


### PR DESCRIPTION
## Summary
- Fixed toast notifications rendering with dark backgrounds despite app being light-only
- Removed unused `next-themes` dependency
- Hardcoded `theme="light"` in Sonner toast component

## Root Cause
`sonner.tsx` imported `useTheme` from `next-themes` but no ThemeProvider existed in the app. This caused the theme to default to "system", which respected OS dark mode settings. When `richColors={true}` + `theme="dark"`, Sonner applied its own dark palette that overrode our custom brutalist classNames.

## Changes
- Removed `useTheme` hook from `sonner.tsx`
- Hardcoded `theme="light"` prop
- Removed `next-themes` package dependency

## Test Plan
- [x] Linting passes
- [x] TypeScript compilation successful
- [ ] Visual verification: toasts render with light backgrounds (emerald-50, red-50) regardless of OS theme
- [ ] Test success/error toasts in Dashboard (pause/activate/delete task)
- [ ] Test toasts in Settings (email verification, API key management)

🤖 Generated with [Claude Code](https://claude.com/claude-code)