### PR TITLE
fix: reload Clerk user in refreshUser to persist welcome metadata

### DIFF
--- a/frontend/src/contexts/ClerkAuthProvider.tsx
+++ b/frontend/src/contexts/ClerkAuthProvider.tsx
@@ -93,6 +93,9 @@ const ClerkAuthWrapper: React.FC<{ children: ReactNode }> = ({ children }) => {
     // Refresh user data from backend (used after mutations like username change)
     if (!clerkUser) return
 
+    // Reload Clerk user to pick up server-side metadata changes (e.g., has_seen_welcome)
+    await clerkUser.reload()
+
     const { api } = await import('@/lib/api')
     const userData = await api.getCurrentUser()
     setBackendUser(createUserFromData(userData, clerkUser))


### PR DESCRIPTION
The welcome screen kept reappearing because refreshUser() used a stale
clerkUser reference after the backend updated public_metadata server-side.
Adding clerkUser.reload() ensures the Clerk SDK fetches the latest
metadata (including has_seen_welcome) before rebuilding the user object.

https://claude.ai/code/session_018dbgcymdGNXSL8KZiCNwhz