### PR TITLE
fix: add rate limiting to sensitive endpoints

### DIFF
--- a/backend/src/torale/api/rate_limiter.py
+++ b/backend/src/torale/api/rate_limiter.py
@@ -2,6 +2,16 @@
 
 from slowapi import Limiter
 from slowapi.util import get_remote_address
+from starlette.requests import Request
+
+
+def get_user_or_ip(request: Request) -> str:
+    """Extract auth token as rate limit key for authenticated endpoints, falling back to IP."""
+    auth = request.headers.get("authorization", "")
+    if auth.startswith("Bearer "):
+        return f"user:{auth[7:]}"
+    return get_remote_address(request)
+
 
 # Global rate limiter for public endpoints (based on IP)
 limiter = Limiter(key_func=get_remote_address)

--- a/backend/src/torale/api/rate_limiter.py
+++ b/backend/src/torale/api/rate_limiter.py
@@ -1,5 +1,7 @@
 """Shared rate limiter configuration for public endpoints."""
 
+import hashlib
+
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from starlette.requests import Request
@@ -9,7 +11,7 @@ def get_user_or_ip(request: Request) -> str:
     """Extract auth token as rate limit key for authenticated endpoints, falling back to IP."""
     auth = request.headers.get("authorization", "")
     if auth.startswith("Bearer "):
-        return f"user:{auth[7:]}"
+        return f"user:{hashlib.sha256(auth[7:].encode()).hexdigest()[:16]}"
     return get_remote_address(request)
 
 

--- a/backend/src/torale/api/routers/auth.py
+++ b/backend/src/torale/api/routers/auth.py
@@ -23,7 +23,7 @@ from torale.access import (
     User as AuthUser,
 )
 from torale.access.models import UserRead
-from torale.api.rate_limiter import limiter
+from torale.api.rate_limiter import get_user_or_ip, limiter
 from torale.core.database import Database, get_db
 
 router = APIRouter()
@@ -163,7 +163,7 @@ class CreateAPIKeyResponse(BaseModel):
 
 
 @router.post("/api-keys", response_model=CreateAPIKeyResponse)
-@limiter.limit("3/minute")
+@limiter.limit("3/minute", key_func=get_user_or_ip)
 async def create_api_key(
     body: CreateAPIKeyRequest,
     request: Request,

--- a/backend/src/torale/api/routers/auth.py
+++ b/backend/src/torale/api/routers/auth.py
@@ -7,7 +7,7 @@ from typing import Annotated
 
 import asyncpg
 import bcrypt
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel
 
 from torale.access import (
@@ -23,6 +23,7 @@ from torale.access import (
     User as AuthUser,
 )
 from torale.access.models import UserRead
+from torale.api.rate_limiter import limiter
 from torale.core.database import Database, get_db
 
 router = APIRouter()
@@ -162,8 +163,10 @@ class CreateAPIKeyResponse(BaseModel):
 
 
 @router.post("/api-keys", response_model=CreateAPIKeyResponse)
+@limiter.limit("3/minute")
 async def create_api_key(
-    request: CreateAPIKeyRequest,
+    body: CreateAPIKeyRequest,
+    request: Request,
     clerk_user: Annotated[AuthUser, Depends(require_developer)],
     db: Database = Depends(get_db),
 ):
@@ -205,7 +208,7 @@ async def create_api_key(
         user_id=user_row["id"],
         key_prefix=key_prefix,
         key_hash=key_hash,
-        name=request.name,
+        name=body.name,
     )
 
     return CreateAPIKeyResponse(

--- a/backend/src/torale/api/routers/email_verification.py
+++ b/backend/src/torale/api/routers/email_verification.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, EmailStr
 
 from torale.access import CurrentUser
-from torale.api.rate_limiter import limiter
+from torale.api.rate_limiter import get_user_or_ip, limiter
 from torale.core.database import Database, get_db
 from torale.notifications import EmailVerificationService
 from torale.notifications.novu_service import novu_service
@@ -26,7 +26,7 @@ class VerificationConfirm(BaseModel):
 
 
 @router.post("/send")
-@limiter.limit("5/minute")
+@limiter.limit("5/minute", key_func=get_user_or_ip)
 async def send_verification_email(
     body: VerificationRequest, request: Request, user: CurrentUser, db: Database = Depends(get_db)
 ):

--- a/backend/src/torale/api/routers/email_verification.py
+++ b/backend/src/torale/api/routers/email_verification.py
@@ -1,9 +1,10 @@
 """Email verification API endpoints."""
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, EmailStr
 
 from torale.access import CurrentUser
+from torale.api.rate_limiter import limiter
 from torale.core.database import Database, get_db
 from torale.notifications import EmailVerificationService
 from torale.notifications.novu_service import novu_service
@@ -25,8 +26,9 @@ class VerificationConfirm(BaseModel):
 
 
 @router.post("/send")
+@limiter.limit("5/minute")
 async def send_verification_email(
-    request: VerificationRequest, user: CurrentUser, db: Database = Depends(get_db)
+    body: VerificationRequest, request: Request, user: CurrentUser, db: Database = Depends(get_db)
 ):
     """
     Send verification code to email address.
@@ -35,12 +37,12 @@ async def send_verification_email(
     """
     async with db.acquire() as conn:
         # Check if already verified
-        if await EmailVerificationService.is_email_verified(conn, str(user.id), request.email):
+        if await EmailVerificationService.is_email_verified(conn, str(user.id), body.email):
             return {"message": "Email already verified"}
 
         # Create verification
         success, code, error = await EmailVerificationService.create_verification(
-            conn, str(user.id), request.email
+            conn, str(user.id), body.email
         )
 
         if not success:
@@ -55,12 +57,10 @@ async def send_verification_email(
         )
 
         # Send verification email via Novu (or log code if not configured)
-        await novu_service.send_verification_email(
-            email=request.email, code=code, user_name=user_name
-        )
+        await novu_service.send_verification_email(email=body.email, code=code, user_name=user_name)
 
         return {
-            "message": f"Verification code sent to {request.email}",
+            "message": f"Verification code sent to {body.email}",
             "expires_in_minutes": EmailVerificationService.VERIFICATION_EXPIRY_MINUTES,
         }
 

--- a/backend/src/torale/api/routers/webhooks.py
+++ b/backend/src/torale/api/routers/webhooks.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, HttpUrl
 
 from torale.access import CurrentUser
-from torale.api.rate_limiter import limiter
+from torale.api.rate_limiter import get_user_or_ip, limiter
 from torale.core.database import Database, get_db
 from torale.notifications import (
     WebhookDeliveryService,
@@ -90,7 +90,7 @@ async def update_user_webhook_config(
 
 
 @router.post("/test")
-@limiter.limit("5/minute")
+@limiter.limit("5/minute", key_func=get_user_or_ip)
 async def test_webhook(request: Request, test_req: WebhookTestRequest, user: CurrentUser):
     """
     Test webhook delivery with sample payload.

--- a/backend/src/torale/api/routers/webhooks.py
+++ b/backend/src/torale/api/routers/webhooks.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, HttpUrl
 
 from torale.access import CurrentUser
+from torale.api.rate_limiter import limiter
 from torale.core.database import Database, get_db
 from torale.notifications import (
     WebhookDeliveryService,
@@ -89,7 +90,8 @@ async def update_user_webhook_config(
 
 
 @router.post("/test")
-async def test_webhook(test_req: WebhookTestRequest, user: CurrentUser):
+@limiter.limit("5/minute")
+async def test_webhook(request: Request, test_req: WebhookTestRequest, user: CurrentUser):
     """
     Test webhook delivery with sample payload.
 

--- a/backend/tests/test_email_verification_endpoints.py
+++ b/backend/tests/test_email_verification_endpoints.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 
 from torale.api.routers.email_verification import (
     VerificationConfirm,
@@ -14,6 +14,19 @@ from torale.api.routers.email_verification import (
     send_verification_email,
     verify_email_code,
 )
+
+
+@pytest.fixture
+def mock_request():
+    """Create a real Request for rate-limited endpoints (slowapi requires it)."""
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/email-verification/send",
+        "headers": [],
+        "client": ("127.0.0.1", 1234),
+    }
+    return Request(scope=scope)
 
 
 @pytest.fixture
@@ -53,9 +66,9 @@ class TestSendVerificationEmail:
     """Tests for send_verification_email endpoint."""
 
     @pytest.mark.asyncio
-    async def test_send_to_new_email(self, mock_user, mock_db):
+    async def test_send_to_new_email(self, mock_user, mock_db, mock_request):
         """Test sending verification code to new email."""
-        request = VerificationRequest(email="new@example.com")
+        body = VerificationRequest(email="new@example.com")
 
         # Get the connection that will be returned by the context manager
         conn = await mock_db.acquire().__aenter__()
@@ -78,30 +91,30 @@ class TestSendVerificationEmail:
                     "torale.api.routers.email_verification.novu_service.send_verification_email",
                     new_callable=AsyncMock,
                 ) as mock_novu:
-                    result = await send_verification_email(request, mock_user, mock_db)
+                    result = await send_verification_email(body, mock_request, mock_user, mock_db)
 
                     assert "Verification code sent" in result["message"]
                     assert result["expires_in_minutes"] == 15
                     mock_novu.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_already_verified_email(self, mock_user, mock_db):
+    async def test_already_verified_email(self, mock_user, mock_db, mock_request):
         """Test sending verification code to already verified email."""
-        request = VerificationRequest(email="verified@example.com")
+        body = VerificationRequest(email="verified@example.com")
 
         # Mock: email already verified
         with patch(
             "torale.api.routers.email_verification.EmailVerificationService.is_email_verified",
             return_value=True,
         ):
-            result = await send_verification_email(request, mock_user, mock_db)
+            result = await send_verification_email(body, mock_request, mock_user, mock_db)
 
             assert result["message"] == "Email already verified"
 
     @pytest.mark.asyncio
-    async def test_rate_limit_exceeded(self, mock_user, mock_db):
+    async def test_rate_limit_exceeded(self, mock_user, mock_db, mock_request):
         """Test rate limit enforcement (3 verifications/hour)."""
-        request = VerificationRequest(email="new@example.com")
+        body = VerificationRequest(email="new@example.com")
 
         with patch(
             "torale.api.routers.email_verification.EmailVerificationService.is_email_verified",
@@ -113,15 +126,15 @@ class TestSendVerificationEmail:
                 return_value=(False, None, "Rate limit exceeded. Please try again later."),
             ):
                 with pytest.raises(HTTPException) as exc_info:
-                    await send_verification_email(request, mock_user, mock_db)
+                    await send_verification_email(body, mock_request, mock_user, mock_db)
 
                 assert exc_info.value.status_code == 429
                 assert "Rate limit" in exc_info.value.detail
 
     @pytest.mark.asyncio
-    async def test_user_name_fallback(self, mock_user, mock_db):
+    async def test_user_name_fallback(self, mock_user, mock_db, mock_request):
         """Test fallback to email prefix when user has no first name."""
-        request = VerificationRequest(email="new@example.com")
+        body = VerificationRequest(email="new@example.com")
         conn = await mock_db.acquire().__aenter__()
 
         with patch(
@@ -139,7 +152,7 @@ class TestSendVerificationEmail:
                     "torale.api.routers.email_verification.novu_service.send_verification_email",
                     new_callable=AsyncMock,
                 ) as mock_novu:
-                    await send_verification_email(request, mock_user, mock_db)
+                    await send_verification_email(body, mock_request, mock_user, mock_db)
 
                     # Should use email prefix as fallback
                     call_args = mock_novu.call_args[1]

--- a/backend/tests/test_webhook_endpoints.py
+++ b/backend/tests/test_webhook_endpoints.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 
 from torale.api.routers.webhooks import (
     WebhookConfig,
@@ -16,6 +16,19 @@ from torale.api.routers.webhooks import (
 from torale.api.routers.webhooks import (
     test_webhook as webhook_test_handler,
 )
+
+
+@pytest.fixture
+def mock_request():
+    """Create a real Request for rate-limited endpoints (slowapi requires it)."""
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/webhooks/test",
+        "headers": [],
+        "client": ("127.0.0.1", 1234),
+    }
+    return Request(scope=scope)
 
 
 @pytest.fixture
@@ -167,7 +180,7 @@ class TestTestWebhook:
     """Tests for test_webhook endpoint."""
 
     @pytest.mark.asyncio
-    async def test_successful_test_delivery(self, mock_user):
+    async def test_successful_test_delivery(self, mock_user, mock_request):
         """Test successful webhook test delivery."""
         test_req = WebhookTestRequest(
             webhook_url="https://example.com/webhook", webhook_secret="test_secret"
@@ -179,7 +192,7 @@ class TestTestWebhook:
         mock_service.close = AsyncMock()
 
         with patch("torale.api.routers.webhooks.WebhookDeliveryService", return_value=mock_service):
-            result = await webhook_test_handler(test_req, mock_user)
+            result = await webhook_test_handler(mock_request, test_req, mock_user)
 
             assert result["success"] is True
             assert "200" in result["message"]
@@ -187,7 +200,7 @@ class TestTestWebhook:
             mock_service.close.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_failed_test_delivery(self, mock_user):
+    async def test_failed_test_delivery(self, mock_user, mock_request):
         """Test failed webhook test delivery."""
         test_req = WebhookTestRequest(
             webhook_url="https://example.com/webhook", webhook_secret="test_secret"
@@ -200,14 +213,14 @@ class TestTestWebhook:
 
         with patch("torale.api.routers.webhooks.WebhookDeliveryService", return_value=mock_service):
             with pytest.raises(HTTPException) as exc_info:
-                await webhook_test_handler(test_req, mock_user)
+                await webhook_test_handler(mock_request, test_req, mock_user)
 
             assert exc_info.value.status_code == 400
             assert "Connection timeout" in exc_info.value.detail
             mock_service.close.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_test_webhook_payload_structure(self, mock_user):
+    async def test_test_webhook_payload_structure(self, mock_user, mock_request):
         """Test that test webhook sends correct payload structure."""
         test_req = WebhookTestRequest(
             webhook_url="https://example.com/webhook", webhook_secret="test_secret"
@@ -229,7 +242,7 @@ class TestTestWebhook:
         mock_service.close = AsyncMock()
 
         with patch("torale.api.routers.webhooks.WebhookDeliveryService", return_value=mock_service):
-            await webhook_test_handler(test_req, mock_user)
+            await webhook_test_handler(mock_request, test_req, mock_user)
 
 
 class TestListWebhookDeliveries:


### PR DESCRIPTION
## Summary
- Add rate limiting to email verification (`POST /email-verification/send` — 5/min)
- Add rate limiting to API key creation (`POST /auth/api-keys` — 3/min)
- Add rate limiting to webhook test (`POST /webhooks/test` — 5/min)

Uses the existing SlowAPI `limiter` infrastructure already in place for public endpoints.

## Test plan
- [ ] Verify email verification endpoint returns 429 after 5 requests/minute
- [ ] Verify API key creation endpoint returns 429 after 3 requests/minute
- [ ] Verify webhook test endpoint returns 429 after 5 requests/minute
- [ ] Verify other endpoints on the same routers are unaffected