### PR TITLE
fix: disable API docs in prod and strip user_id from public endpoints

### DIFF
--- a/backend/src/torale/api/main.py
+++ b/backend/src/torale/api/main.py
@@ -135,6 +135,9 @@ app = FastAPI(
     description="Platform-agnostic background task manager for AI-powered automation",
     version="0.1.0",
     lifespan=lifespan,
+    docs_url="/docs" if settings.torale_noauth else None,
+    redoc_url="/redoc" if settings.torale_noauth else None,
+    openapi_url="/openapi.json" if settings.torale_noauth else None,
 )
 
 _CORS_ORIGINS = [

--- a/backend/src/torale/api/routers/public_tasks.py
+++ b/backend/src/torale/api/routers/public_tasks.py
@@ -5,7 +5,7 @@ from email.utils import format_datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 from torale.access import OptionalUser
 from torale.api.rate_limiter import limiter
@@ -25,10 +25,17 @@ ET.register_namespace("atom", "http://www.w3.org/2005/Atom")
 router = APIRouter(prefix="/public", tags=["public"])
 
 
+class PublicTask(Task):
+    """Task model with user_id stripped for public responses."""
+
+    model_config = ConfigDict(from_attributes=True)
+    user_id: None = Field(default=None, exclude=True)
+
+
 class PublicTasksResponse(BaseModel):
     """Response for public tasks listing."""
 
-    tasks: list[Task]
+    tasks: list[PublicTask]
     total: int
     offset: int
     limit: int
@@ -95,7 +102,7 @@ async def list_public_tasks(
             task = task.model_copy(
                 update={"notification_email": None, "webhook_url": None, "notifications": []}
             )
-        scrubbed_tasks.append(task)
+        scrubbed_tasks.append(PublicTask.model_validate(task))
 
     return PublicTasksResponse(
         tasks=scrubbed_tasks,
@@ -121,7 +128,7 @@ async def get_public_feed(
     )
 
 
-@router.get("/tasks/id/{task_id}", response_model=Task)
+@router.get("/tasks/id/{task_id}", response_model=PublicTask)
 @limiter.limit("20/minute")
 async def get_public_task_by_id(
     request: Request,
@@ -133,7 +140,8 @@ async def get_public_task_by_id(
     Get a public task by UUID (NO AUTH REQUIRED).
     """
     # Delegates to the shared get_task logic (handles owner vs public access)
-    return await get_task(task_id, user, db)
+    task = await get_task(task_id, user, db)
+    return PublicTask.model_validate(task)
 
 
 # Separate router for root-level RSS feed (mounted without /api/v1 prefix)

--- a/backend/src/torale/api/routers/public_tasks.py
+++ b/backend/src/torale/api/routers/public_tasks.py
@@ -34,9 +34,7 @@ class PublicTask(Task):
 class PublicFeedExecution(FeedExecution):
     """Feed execution with task_user_id stripped for public responses."""
 
-    model_config = ConfigDict(
-        from_attributes=True, fields={"task_user_id": {"exclude": True}}
-    )
+    model_config = ConfigDict(from_attributes=True, fields={"task_user_id": {"exclude": True}})
 
 
 class PublicTasksResponse(BaseModel):

--- a/backend/src/torale/api/routers/public_tasks.py
+++ b/backend/src/torale/api/routers/public_tasks.py
@@ -5,7 +5,7 @@ from email.utils import format_datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 
 from torale.access import OptionalUser
 from torale.api.rate_limiter import limiter
@@ -28,8 +28,15 @@ router = APIRouter(prefix="/public", tags=["public"])
 class PublicTask(Task):
     """Task model with user_id stripped for public responses."""
 
-    model_config = ConfigDict(from_attributes=True)
-    user_id: None = Field(default=None, exclude=True)
+    model_config = ConfigDict(from_attributes=True, fields={"user_id": {"exclude": True}})
+
+
+class PublicFeedExecution(FeedExecution):
+    """Feed execution with task_user_id stripped for public responses."""
+
+    model_config = ConfigDict(
+        from_attributes=True, fields={"task_user_id": {"exclude": True}}
+    )
 
 
 class PublicTasksResponse(BaseModel):
@@ -112,7 +119,7 @@ async def list_public_tasks(
     )
 
 
-@router.get("/feed", response_model=list[FeedExecution])
+@router.get("/feed", response_model=list[PublicFeedExecution])
 @limiter.limit("10/minute")
 async def get_public_feed(
     request: Request,
@@ -123,9 +130,10 @@ async def get_public_feed(
     Get a global feed of recent successful executions across all public tasks.
     Only returns executions that produced a notification (condition met).
     """
-    return await fetch_feed_executions(
+    executions = await fetch_feed_executions(
         db, where_clause="t.is_public = true", params=[], limit=limit
     )
+    return [PublicFeedExecution.model_validate(e) for e in executions]
 
 
 @router.get("/tasks/id/{task_id}", response_model=PublicTask)


### PR DESCRIPTION
## Summary
- Disable Swagger/OpenAPI docs (`/docs`, `/redoc`, `/openapi.json`) in production by gating on `torale_noauth` setting
- Strip `user_id` from all public task endpoint responses via a `PublicTask` model that excludes the field during serialization

## Changes
- `backend/src/torale/api/main.py`: Add conditional `docs_url`, `redoc_url`, `openapi_url` params to FastAPI app
- `backend/src/torale/api/routers/public_tasks.py`: Add `PublicTask` response model, apply to `/public/tasks` and `/public/tasks/id/{task_id}` endpoints

## Test plan
- [ ] All 218 existing tests pass
- [ ] Verify `/docs` returns 404 when `TORALE_NOAUTH` is not set
- [ ] Verify `/api/v1/public/tasks` response does not contain `user_id` field
- [ ] Verify `/api/v1/public/tasks/id/{id}` response does not contain `user_id` field