### PR TITLE
fix: execution row reuse, stale errors, confidence x100

### DIFF
--- a/backend/src/torale/notifications/novu_service.py
+++ b/backend/src/torale/notifications/novu_service.py
@@ -33,11 +33,11 @@ def _format_next_run(next_run: str | None) -> str | None:
     return dt.strftime("%B %d, %Y at %I:%M %p")
 
 
-def _format_confidence(confidence: float | None) -> str | None:
-    """Format confidence as percentage string for Novu templates."""
+def _format_confidence(confidence: int | None) -> str | None:
+    """Format confidence (0-100) as percentage string for Novu templates."""
     if confidence is None:
         return None
-    return f"{round(confidence * 100)}%"
+    return f"{confidence}%"
 
 
 def _md_to_html(text: str, extensions: list[str] | None = None) -> str:
@@ -122,7 +122,7 @@ class NovuService:
         self,
         payload: NotificationPayload,
         execution_id: str,
-        confidence: float | None = None,
+        confidence: int | None = None,
     ) -> dict:
         """Send notification when monitoring condition is met."""
         return await self._trigger(

--- a/backend/src/torale/scheduler/job.py
+++ b/backend/src/torale/scheduler/job.py
@@ -394,14 +394,18 @@ async def _execute(
                 logger.error(f"Auto-complete failed for task {task_id}: {e}", exc_info=True)
                 await _merge_execution_result(execution_id, {"auto_complete_failed": True})
         elif execution_succeeded:
-            # Agent returned a next_run date → schedule next check
+            # Agent returned a next_run date → schedule next check.
+            # Pass execution_id=None so the next scheduled run creates its own
+            # row. Reusing the current execution_id would cause subsequent runs
+            # to overwrite this row's completed_at, producing inflated durations
+            # and collapsing history.
             resolved_dt = _resolve_next_run(next_run_value)
             await _schedule_next_run(
                 task_id=task_id,
                 user_id=user_id,
                 task_name=task_name,
                 next_run_dt=resolved_dt,
-                execution_id=execution_id,
+                execution_id=None,
                 retry_count=0,  # Reset retry count on successful execution
             )
 

--- a/backend/src/torale/scheduler/job.py
+++ b/backend/src/torale/scheduler/job.py
@@ -127,8 +127,21 @@ async def _execute(
     start_time = time.monotonic()
 
     try:
+        # Clear any terminal-state leftovers from a prior attempt on the same row.
+        # Within a single execution lifecycle, retries reuse execution_id, so the
+        # row may still hold error_message/internal_error/error_category from the
+        # failed prior attempt, or transient flags like notification_failed /
+        # auto_complete_failed merged into result. Clearing here keeps the
+        # invariant "a RUNNING row is clean" and is a no-op for fresh rows.
         await db.execute(
-            "UPDATE task_executions SET status = $2 WHERE id = $1",
+            """UPDATE task_executions
+               SET status = $2,
+                   error_message = NULL,
+                   internal_error = NULL,
+                   error_category = NULL,
+                   completed_at = NULL,
+                   result = '{}'::jsonb
+               WHERE id = $1""",
             uuid.UUID(execution_id),
             TaskStatus.RUNNING.value,
         )

--- a/backend/tests/test_job.py
+++ b/backend/tests/test_job.py
@@ -165,6 +165,31 @@ class TestExecute:
         assert call_kwargs.kwargs["id"] == f"task-{TASK_ID}"
 
     @pytest.mark.asyncio
+    async def test_running_transition_clears_prior_error_fields(self, job_mocks):
+        """On entry to _execute, the RUNNING-state UPDATE must clear error fields.
+
+        Regression: retries reuse execution_id, so the row still holds
+        error_message / internal_error / error_category from the failed prior
+        attempt. If a retry then succeeds, persist_execution_result updates
+        status but doesn't touch the error columns, leaving the success row
+        with a stale user-facing error message.
+        """
+        job_mocks.db.fetch_one = AsyncMock(return_value=_make_task_row())
+        job_mocks.agent.return_value = _make_agent_response()
+
+        await _execute(TASK_ID, EXECUTION_ID, USER_ID, TASK_NAME)
+
+        # The first db.execute call should be the RUNNING state transition,
+        # and it must clear error fields, completed_at, and stale result flags.
+        first_sql = job_mocks.db.execute.call_args_list[0].args[0]
+        assert "status = $2" in first_sql
+        assert "error_message = NULL" in first_sql
+        assert "internal_error = NULL" in first_sql
+        assert "error_category = NULL" in first_sql
+        assert "completed_at = NULL" in first_sql
+        assert "result = '{}'::jsonb" in first_sql
+
+    @pytest.mark.asyncio
     async def test_retry_path_preserves_execution_id(self, job_mocks):
         """Failed-attempt retries must share a row by forwarding execution_id.
 

--- a/backend/tests/test_job.py
+++ b/backend/tests/test_job.py
@@ -165,6 +165,59 @@ class TestExecute:
         assert call_kwargs.kwargs["id"] == f"task-{TASK_ID}"
 
     @pytest.mark.asyncio
+    async def test_retry_path_preserves_execution_id(self, job_mocks):
+        """Failed-attempt retries must share a row by forwarding execution_id.
+
+        Locks in the intentional asymmetry with the success path: a retry is
+        the same logical attempt and should reuse the task_executions row, so
+        the user sees one row per lifecycle rather than one row per retry
+        delay. Only successful follow-ups get a fresh row (see
+        test_successful_scheduled_run_does_not_forward_execution_id).
+        """
+        job_mocks.db.fetch_one = AsyncMock(return_value=_make_task_row())
+        job_mocks.agent.side_effect = RuntimeError("Transient agent failure")
+
+        mock_sched = MagicMock()
+        job_mocks.scheduler.return_value = mock_sched
+
+        await _execute(TASK_ID, EXECUTION_ID, USER_ID, TASK_NAME, retry_count=0)
+
+        # An UNKNOWN error at retry_count=0 is retried, so the scheduler must
+        # get called with a retry job whose APScheduler args still hold the
+        # current execution_id (unlike the success path).
+        mock_sched.add_job.assert_called_once()
+        args = mock_sched.add_job.call_args.kwargs["args"]
+        assert args[0] == TASK_ID
+        assert args[3] == 1  # retry_count incremented
+        assert args[4] == EXECUTION_ID  # execution_id IS forwarded on retries
+
+    @pytest.mark.asyncio
+    async def test_successful_scheduled_run_does_not_forward_execution_id(self, job_mocks):
+        """Successful scheduled runs must not reuse execution_id for the next run.
+
+        Regression: previously the success path passed the current execution_id
+        to _schedule_next_run, which persisted it into APScheduler args. The
+        next scheduled run would then overwrite the same task_executions row,
+        leaving started_at from the first run and clobbering completed_at on
+        every subsequent run -- producing multi-day "durations" and collapsing
+        execution history onto one row per task.
+        """
+        job_mocks.db.fetch_one = AsyncMock(return_value=_make_task_row())
+        future_time = (datetime.now(UTC) + timedelta(hours=2)).isoformat()
+        job_mocks.agent.return_value = _make_agent_response(next_run=future_time)
+
+        mock_sched = MagicMock()
+        job_mocks.scheduler.return_value = mock_sched
+
+        await _execute(TASK_ID, EXECUTION_ID, USER_ID, TASK_NAME)
+
+        # APScheduler job args are [task_id, user_id, task_name, retry_count, execution_id]
+        args = mock_sched.add_job.call_args.kwargs["args"]
+        assert args[0] == TASK_ID
+        assert args[3] == 0  # retry_count reset
+        assert args[4] is None  # execution_id NOT forwarded
+
+    @pytest.mark.asyncio
     async def test_execute_task_job_delegates_to_execute(self, job_mocks):
         """execute_task_job delegates to _execute with execution_id=None."""
         job_mocks.db.fetch_one = AsyncMock(return_value=_make_task_row())

--- a/backend/tests/test_novu_service.py
+++ b/backend/tests/test_novu_service.py
@@ -1,0 +1,26 @@
+"""Tests for Novu notification helpers."""
+
+import pytest
+
+from torale.notifications.novu_service import _format_confidence
+
+
+class TestFormatConfidence:
+    """Confidence arrives as int 0-100 (MonitoringResponse schema).
+
+    Regression: a prior version multiplied by 100, producing "9500%"/"10000%"
+    in notification emails.
+    """
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, None),
+            (0, "0%"),
+            (50, "50%"),
+            (95, "95%"),
+            (100, "100%"),
+        ],
+    )
+    def test_format(self, value, expected):
+        assert _format_confidence(value) == expected


### PR DESCRIPTION
## Summary

Three related bugs surfaced while debugging a failed execution in prod on task `1d0dba13-...`. Shipped as three separate commits on the same branch to keep the history bisectable.

### Fix 1 — `42b71ce` don't reuse execution_id across scheduled runs

On the success path of `_execute`, `_schedule_next_run` was called with `execution_id=execution_id`, which persisted the current execution_id into the APScheduler job args for the **next** scheduled run. That run would then reuse the same `task_executions` row, overwriting `completed_at` while leaving `started_at` from the first run.

Evidence from prod DB for this task:

\`\`\`
2026-02-11 00:20:21 -> 2026-04-03 09:15:25  (4,438,504s, retry=0)  status=success
2026-04-06 19:35:52 -> 2026-04-09 19:56:30  (260,438s,   retry=1)  status=success
\`\`\`

Those multi-day "durations" are just (latest run's completed_at) minus (first run's started_at). `git blame` traces the bug to commit `aa221a0e` (Feb 2) in the APScheduler refactor, which matches the first anomalous row in the data (Feb 11).

Fix: pass `execution_id=None` on the success path. Each scheduled follow-up run now creates its own row via `create_execution_record`. The failure-retry path (line 370) still passes `execution_id=execution_id` intentionally — a retry of the *same* logical attempt should share the row.

### Fix 2 — `e8046e7` clear stale error fields when execution transitions to running

Within a single execution lifecycle, retries reuse the same row. The RUNNING state transition at the top of `_execute` only set `status`, leaving `error_message`, `internal_error`, `error_category`, and `completed_at` populated from the failed prior attempt. If the retry succeeded, `persist_execution_result` updated status/result/completed_at but didn't touch the error columns, leaving a "success" row with a stale user-facing error message.

Result in the admin UI: green SUCCESS badge rendered next to a red "An unexpected error occurred. We'll retry automatically." message on the same card.

Fix: extend the RUNNING transition UPDATE to NULL the error columns and completed_at. Idempotent on fresh rows.

### Fix 3 — `29c9611` remove x100 multiplier from confidence formatter

Novu notification emails showed "Confidence: 10000%" and "Confidence: 9500%". `_format_confidence` in `novu_service.py` did `f"{round(confidence * 100)}%"`, but the agent's `MonitoringResponse` schema defines `confidence: int` in range 0-100 (enforced by Pydantic `Field(ge=0, le=100)` in both `torale-agent/models.py` and `backend/src/torale/scheduler/models.py`). The admin frontend (`TaskDetailPanel.tsx:333`) already rendered it correctly as `${confidence}%`, confirming 0-100 is the intended contract.

Fix: drop the `* 100`, correct the misleading `float | None` type hint to `int | None`.

## Test plan

- [x] `just test` — 225 passed, 0 failures
- [x] Regression test: `test_successful_scheduled_run_does_not_forward_execution_id` asserts APScheduler args have `execution_id=None` after a successful run
- [x] Regression test: `test_running_transition_clears_prior_error_fields` asserts the RUNNING UPDATE SQL clears error columns
- [x] New `test_novu_service.py::TestFormatConfidence` parametrized over `None / 0 / 50 / 95 / 100`
- [x] `ruff check` clean on all modified files
- [ ] Post-deploy: verify `SELECT task_id, MAX(EXTRACT(EPOCH FROM (completed_at - started_at))) FROM task_executions WHERE started_at > NOW() - INTERVAL '1 day' GROUP BY task_id` — max duration stays in seconds, not days
- [ ] Post-deploy: trigger a manual task execution and inspect the Novu email — confidence renders as e.g. "95%" not "9500%"
- [ ] Post-deploy: new successful retries no longer carry stale error_message in the admin UI

## Out of scope

- Backfilling historical rows with inflated durations or stale error fields — rolls off naturally as new scheduled runs create fresh rows.
- Reclassifying Gemini 503 errors from `unknown` to `rate_limit` in `errors.py` — separate concern, track separately.