### PR TITLE
fix: use HTTPS in RSS feed self-link

### DIFF
--- a/backend/src/torale/api/routers/public_tasks.py
+++ b/backend/src/torale/api/routers/public_tasks.py
@@ -184,7 +184,9 @@ async def get_task_rss_feed(
     executions = await db.fetch_all(executions_query, task_id)
 
     task_link = f"{settings.frontend_url}/tasks/{task_id}"
-    feed_url = str(request.url_for("get_task_rss_feed", task_id=task_id))
+    feed_url = str(request.url_for("get_task_rss_feed", task_id=task_id)).replace(
+        "http://", "https://", 1
+    )
 
     # Build RSS 2.0 feed
     rss = ET.Element("rss", version="2.0")


### PR DESCRIPTION
## Summary

The atom self-link in public task RSS feeds used `http://` because `request.url_for()` reflects the internal scheme behind the GKE TLS-terminating load balancer. Feed readers see `http://api.torale.ai` instead of `https://api.torale.ai`.

Fix: replace `http://` with `https://` in the generated URL, matching the standard pattern for services behind reverse proxies.

## Test plan

- [x] 226 backend tests pass
- [ ] `curl https://api.torale.ai/tasks/{id}/rss` shows `https://` in atom:link href