### PR TITLE
feat: expose Torale API surface for external integrations

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "torale",
+  "owner": {
+    "name": "Torale",
+    "email": "hello@torale.ai"
+  },
+  "metadata": {
+    "description": "AI-powered web monitoring plugins"
+  },
+  "plugins": [
+    {
+      "name": "torale",
+      "source": "..",
+      "description": "Monitor the web for conditions and get notified when they're met",
+      "version": "0.1.0",
+      "author": {
+        "name": "Torale"
+      },
+      "homepage": "https://torale.ai",
+      "keywords": ["monitoring", "web", "search", "alerts", "webhooks"],
+      "category": "automation"
+    }
+  ]
+}

--- a/backend/alembic/versions/a7b8c9d0e1f2_add_task_context.py
+++ b/backend/alembic/versions/a7b8c9d0e1f2_add_task_context.py
@@ -1,0 +1,28 @@
+"""add_task_context
+
+Revision ID: a7b8c9d0e1f2
+Revises: e1f2a3b4c5d6
+Create Date: 2026-04-13 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a7b8c9d0e1f2"
+down_revision: str = "e1f2a3b4c5d6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("tasks", sa.Column("context", postgresql.JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("tasks", "context")

--- a/backend/src/torale/api/routers/auth.py
+++ b/backend/src/torale/api/routers/auth.py
@@ -3,7 +3,6 @@
 import secrets
 import uuid
 from datetime import UTC, datetime
-from typing import Annotated
 
 import asyncpg
 import bcrypt
@@ -17,10 +16,6 @@ from torale.access import (
     ProductionAuthProvider,
     UserRepository,
     get_auth_provider,
-    require_developer,
-)
-from torale.access import (
-    User as AuthUser,
 )
 from torale.access.models import UserRead
 from torale.api.rate_limiter import get_user_or_ip, limiter
@@ -167,13 +162,12 @@ class CreateAPIKeyResponse(BaseModel):
 async def create_api_key(
     body: CreateAPIKeyRequest,
     request: Request,
-    clerk_user: Annotated[AuthUser, Depends(require_developer)],
+    clerk_user: CurrentUser,
     db: Database = Depends(get_db),
 ):
     """
     Generate a new API key for SDK authentication.
 
-    Requires developer role in Clerk publicMetadata.
     Returns the full key once - store it securely!
     """
     user_row = await db.fetch_one(

--- a/backend/src/torale/api/routers/tasks.py
+++ b/backend/src/torale/api/routers/tasks.py
@@ -7,16 +7,18 @@ from uuid import UUID
 
 from apscheduler.jobstores.base import JobLookupError
 from asyncpg.exceptions import UniqueViolationError
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, Field
 
 from torale.access import CurrentUser, OptionalUser
+from torale.api.rate_limiter import get_user_or_ip, limiter
 from torale.api.utils.task_parsers import (
     fetch_feed_executions,
     parse_execution_row,
     parse_task_row,
     parse_task_with_execution,
 )
+from torale.core.config import settings
 from torale.core.database import Database, get_db
 from torale.core.views import increment_view
 from torale.notifications import NotificationValidationError, validate_notification
@@ -126,12 +128,25 @@ async def _validate_and_extract_notifications(
 
 
 @router.post("/", response_model=Task)
+@limiter.limit("10/minute", key_func=get_user_or_ip)
 async def create_task(
+    request: Request,
     task: TaskCreate,
     user: CurrentUser,
     background_tasks: BackgroundTasks,
     db: Database = Depends(get_db),
 ):
+    if task.state == TaskState.ACTIVE:
+        active_count = await db.fetch_val(
+            "SELECT COUNT(*) FROM tasks WHERE user_id = $1 AND state = 'active'",
+            user.id,
+        )
+        if active_count >= settings.max_active_tasks_per_user:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=f"Maximum of {settings.max_active_tasks_per_user} active tasks reached. Complete or pause existing tasks first.",
+            )
+
     # Validate notifications and extract fields for database
     validated_notifications, extracted = await _validate_and_extract_notifications(
         task.notifications
@@ -145,9 +160,10 @@ async def create_task(
         INSERT INTO tasks (
             user_id, name, state, next_run,
             search_query, condition_description, notifications,
-            notification_channels, notification_email, webhook_url, webhook_secret
+            notification_channels, notification_email, webhook_url, webhook_secret,
+            context
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
         RETURNING *
     """
 
@@ -164,6 +180,7 @@ async def create_task(
         extracted["notification_email"],
         extracted["webhook_url"],
         extracted["webhook_secret"],
+        task.context,
     )
 
     if not row:

--- a/backend/src/torale/core/config.py
+++ b/backend/src/torale/core/config.py
@@ -52,8 +52,9 @@ class Settings(BaseSettings):
     torale_noauth: bool = False
     torale_noauth_email: str = "test@example.com"
 
-    # Platform capacity limit for beta
+    # Platform capacity limits
     max_users: int = 100
+    max_active_tasks_per_user: int = 50
 
     # Redis (optional — for async view counting)
     redis_host: str | None = None

--- a/backend/src/torale/notifications/__init__.py
+++ b/backend/src/torale/notifications/__init__.py
@@ -136,3 +136,5 @@ async def send_notifications(
             )
 
     return results
+
+

--- a/backend/src/torale/notifications/__init__.py
+++ b/backend/src/torale/notifications/__init__.py
@@ -136,5 +136,3 @@ async def send_notifications(
             )
 
     return results
-
-

--- a/backend/src/torale/notifications/webhook.py
+++ b/backend/src/torale/notifications/webhook.py
@@ -96,7 +96,12 @@ class WebhookDeliveryService:
         self.client = httpx.AsyncClient(timeout=self.TIMEOUT)
 
     async def deliver(
-        self, url: str, payload: WebhookPayload, secret: str, attempt: int = 1
+        self,
+        url: str,
+        payload: WebhookPayload,
+        secret: str,
+        attempt: int = 1,
+        custom_headers: dict[str, str] | None = None,
     ) -> tuple[bool, int | None, str | None, str]:
         """
         Deliver webhook with HMAC signature.
@@ -117,6 +122,12 @@ class WebhookDeliveryService:
             "X-Torale-Delivery": payload.id,
             "X-Torale-Timestamp": str(timestamp),
         }
+
+        if custom_headers:
+            reserved = {k.lower() for k in headers}
+            for k, v in custom_headers.items():
+                if k.lower() not in reserved:
+                    headers[k] = v
 
         try:
             response = await self.client.post(url, content=payload_json, headers=headers)
@@ -168,25 +179,31 @@ def build_webhook_payload(
     """
     notification_text = result.get("notification", "")
 
+    data = {
+        "task": {
+            "id": str(task["id"]),
+            "name": task["name"],
+            "search_query": task.get("search_query", ""),
+            "condition_description": task.get("condition_description", ""),
+        },
+        "execution": {
+            "id": execution_id,
+            "notification": notification_text,
+            "completed_at": str(execution.get("completed_at", "")),
+        },
+        "result": {
+            "answer": result.get("summary", ""),
+            "grounding_sources": result.get("sources", []),
+        },
+    }
+
+    task_context = task.get("context")
+    if task_context:
+        data["context"] = task_context
+
     return WebhookPayload(
         id=execution_id,
         event_type="task.condition_met",
         created_at=int(time.time()),
-        data={
-            "task": {
-                "id": str(task["id"]),
-                "name": task["name"],
-                "search_query": task.get("search_query", ""),
-                "condition_description": task.get("condition_description", ""),
-            },
-            "execution": {
-                "id": execution_id,
-                "notification": notification_text,
-                "completed_at": str(execution.get("completed_at", "")),
-            },
-            "result": {
-                "answer": result.get("summary", ""),
-                "grounding_sources": result.get("sources", []),
-            },
-        },
+        data=data,
     )

--- a/backend/src/torale/scheduler/activities.py
+++ b/backend/src/torale/scheduler/activities.py
@@ -271,7 +271,10 @@ async def send_webhook_notification(notification_context: dict, result: dict) ->
     signature: str | None = None
     try:
         success, http_status, error, signature = await service.deliver(
-            webhook_url, payload, webhook_secret, attempt=1,
+            webhook_url,
+            payload,
+            webhook_secret,
+            attempt=1,
             custom_headers=notification_context["webhook_headers"],
         )
     finally:

--- a/backend/src/torale/scheduler/activities.py
+++ b/backend/src/torale/scheduler/activities.py
@@ -121,6 +121,8 @@ async def fetch_notification_context(task_id: str, execution_id: str, user_id: s
     # Parse notification configs from JSONB
     webhook_headers: dict[str, str] | None = None
     raw_notifications = task.get("notifications") or []
+    if isinstance(raw_notifications, str):
+        raw_notifications = json.loads(raw_notifications)
     notifications = [NotificationConfig(**n) for n in raw_notifications]
     for notif in notifications:
         if notif.type == "webhook" and notif.headers:

--- a/backend/src/torale/scheduler/activities.py
+++ b/backend/src/torale/scheduler/activities.py
@@ -17,7 +17,7 @@ from torale.notifications import (
 )
 from torale.notifications.novu_service import NotificationPayload
 from torale.scheduler.history import ExecutionRecord
-from torale.tasks import TaskStatus
+from torale.tasks import NotificationConfig, TaskStatus
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +118,15 @@ async def fetch_notification_context(task_id: str, execution_id: str, user_id: s
     if not execution:
         raise RuntimeError(f"Execution {execution_id} not found")
 
+    # Parse notification configs from JSONB
+    webhook_headers: dict[str, str] | None = None
+    raw_notifications = task.get("notifications") or []
+    notifications = [NotificationConfig(**n) for n in raw_notifications]
+    for notif in notifications:
+        if notif.type == "webhook" and notif.headers:
+            webhook_headers = notif.headers
+            break
+
     return {
         "task": dict(task),
         "execution": dict(execution),
@@ -126,6 +135,7 @@ async def fetch_notification_context(task_id: str, execution_id: str, user_id: s
         "notification_channels": task.get("notification_channels") or ["email"],
         "webhook_url": task.get("webhook_url") or task.get("user_webhook_url"),
         "webhook_secret": task.get("webhook_secret") or task.get("user_webhook_secret"),
+        "webhook_headers": webhook_headers,
     }
 
 
@@ -261,7 +271,8 @@ async def send_webhook_notification(notification_context: dict, result: dict) ->
     signature: str | None = None
     try:
         success, http_status, error, signature = await service.deliver(
-            webhook_url, payload, webhook_secret, attempt=1
+            webhook_url, payload, webhook_secret, attempt=1,
+            custom_headers=notification_context["webhook_headers"],
         )
     finally:
         await service.close()

--- a/backend/src/torale/tasks/tasks.py
+++ b/backend/src/torale/tasks/tasks.py
@@ -52,6 +52,7 @@ class TaskData(TypedDict, total=False):
     notification_email: str | None
     webhook_url: str | None
     webhook_secret: str | None
+    context: dict | None
 
 
 class TaskBase(BaseModel):
@@ -71,6 +72,7 @@ class TaskCreate(TaskBase):
     search_query: str
     condition_description: str | None = None
     run_immediately: bool = False  # Execute task immediately after creation
+    context: dict | None = None
 
 
 class TaskUpdate(BaseModel):
@@ -79,6 +81,7 @@ class TaskUpdate(BaseModel):
     search_query: str | None = None
     condition_description: str | None = None
     notifications: list[NotificationConfig] | None = None
+    context: dict | None = None
 
 
 class TaskExecutionBase(BaseModel):
@@ -131,6 +134,8 @@ class Task(TaskBase):
 
     # Immediate execution error (only set when run_immediately fails during creation)
     immediate_execution_error: str | None = None
+
+    context: dict | None = None
 
     # Shareable tasks fields
     is_public: bool = False

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -1,0 +1,158 @@
+---
+description: Integrate Torale with OpenClaw to add web monitoring to your AI assistant. Watch for conditions and trigger actions when they're met.
+---
+
+# OpenClaw Integration
+
+Use Torale as a web monitoring backend for [OpenClaw](https://openclaw.ai). Torale watches for conditions on the web; OpenClaw acts when they're met.
+
+## How It Works
+
+```
+You (via chat) → OpenClaw → Torale API (create monitor)
+                                  ↓
+                    Torale checks periodically
+                                  ↓
+                    Condition met → webhook → OpenClaw acts
+```
+
+1. You tell OpenClaw to watch for something
+2. OpenClaw creates a Torale task via API
+3. Torale monitors the web on a schedule
+4. When the condition is met, Torale sends a webhook to OpenClaw
+5. OpenClaw receives the notification and takes action
+
+## Setup
+
+### 1. Get a Torale API Key
+
+Sign up at [torale.ai](https://torale.ai) and create an API key in Settings.
+
+### 2. Install the Skill
+
+For Claude Code:
+```bash
+/plugin marketplace add prassanna-ravishankar/torale-openclaw
+/plugin install torale@torale
+```
+
+For OpenClaw:
+```bash
+openclaw skills install torale
+```
+
+### 3. Configure the API Key
+
+```bash
+openclaw config set skills.entries.torale.apiKey "sk_your_key_here"
+```
+
+### 4. Enable Webhooks in OpenClaw
+
+Make sure hooks are enabled in your `~/.openclaw/openclaw.json`:
+
+```json5
+{
+  hooks: {
+    enabled: true,
+    token: "your-hook-secret",
+    path: "/hooks",
+  },
+}
+```
+
+## Usage
+
+Once configured, tell OpenClaw what to watch for:
+
+- "Watch for when Apple announces iPhone 17"
+- "Monitor when Bitcoin crosses $100k and alert me"
+- "Let me know when the Next.js 15 release notes are published, then summarize the changelog"
+
+OpenClaw creates the monitor and Torale handles the rest.
+
+## API Reference
+
+All requests go to `https://api.torale.ai/api/v1` with `Authorization: Bearer sk_...`.
+
+### Create a Monitor
+
+```bash
+curl -X POST https://api.torale.ai/api/v1/tasks \
+  -H "Authorization: Bearer sk_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "iPhone 17 Announcement",
+    "search_query": "Apple iPhone 17 announcement",
+    "condition_description": "Apple officially announces iPhone 17",
+    "notifications": [{
+      "type": "webhook",
+      "url": "https://your-openclaw:18789/hooks/agent",
+      "headers": {"Authorization": "Bearer your-hook-token"}
+    }],
+    "context": {
+      "source": "openclaw",
+      "action": "notify me with key details"
+    }
+  }'
+```
+
+### List Monitors
+
+```bash
+curl https://api.torale.ai/api/v1/tasks \
+  -H "Authorization: Bearer sk_..."
+```
+
+### Delete a Monitor
+
+```bash
+curl -X DELETE https://api.torale.ai/api/v1/tasks/{task_id} \
+  -H "Authorization: Bearer sk_..."
+```
+
+## Webhook Payload
+
+When the condition is met, Torale POSTs to your OpenClaw webhook:
+
+```json
+{
+  "event_type": "task.condition_met",
+  "data": {
+    "task": {
+      "id": "uuid",
+      "name": "iPhone 17 Announcement",
+      "search_query": "Apple iPhone 17 announcement",
+      "condition_description": "Apple officially announces iPhone 17"
+    },
+    "execution": {
+      "notification": "Apple has officially announced the iPhone 17..."
+    },
+    "result": {
+      "answer": "Detailed analysis with evidence...",
+      "grounding_sources": [
+        {"url": "https://apple.com/...", "title": "Apple Newsroom"}
+      ]
+    },
+    "context": {
+      "source": "openclaw",
+      "action": "notify me with key details"
+    }
+  }
+}
+```
+
+The `context` object is passed through from task creation, so OpenClaw knows what action to take.
+
+## HTTPS Requirement
+
+Torale requires webhook URLs to use HTTPS. If your OpenClaw instance runs locally on HTTP, expose it via [Tailscale](https://docs.openclaw.ai/gateway/tailscale) or a reverse proxy with TLS.
+
+## Authentication
+
+Torale uses HMAC-SHA256 signing (Stripe-compatible) on all webhook deliveries. The signature is in the `X-Torale-Signature` header. OpenClaw authenticates via the `Authorization: Bearer` header you configure in the notification.
+
+## Rate Limits
+
+- Task creation: 10 per minute
+- Maximum active tasks: 50 per user

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "torale",
+  "version": "0.1.0",
+  "description": "Monitor the web for conditions and get notified when they're met",
+  "author": {
+    "name": "Torale",
+    "email": "hello@torale.ai"
+  },
+  "homepage": "https://torale.ai",
+  "repository": "https://github.com/prassanna-ravishankar/torale",
+  "license": "MIT",
+  "skills": "./skills"
+}

--- a/skills/torale/SKILL.md
+++ b/skills/torale/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: torale
+description: Monitor the web for conditions using AI-powered grounded search and get notified when they're met
+metadata: {"openclaw": {"requires": {"env": ["TORALE_API_KEY"]}, "primaryEnv": "TORALE_API_KEY", "emoji": "👁️"}}
+---
+
+# Torale - Web Monitoring
+
+Monitor the web for specific conditions using AI-powered grounded search.
+Torale watches for things so you don't have to. When a condition is met, it sends a webhook notification.
+
+## Setup
+
+1. Sign up at https://torale.ai and get an API key from Settings
+2. Set `TORALE_API_KEY` environment variable to your API key
+
+## API
+
+Base URL: `https://api.torale.ai/api/v1`
+
+All requests require the header: `Authorization: Bearer {TORALE_API_KEY}`
+
+### Create a monitor
+
+When a user wants to watch for something on the web, create a task:
+
+```
+POST /tasks
+Content-Type: application/json
+
+{
+  "name": "<short descriptive name>",
+  "search_query": "<what to search for>",
+  "condition_description": "<specific condition that triggers notification>",
+  "notifications": [
+    {
+      "type": "webhook",
+      "url": "<webhook URL to receive notifications>",
+      "headers": {"Authorization": "Bearer <webhook auth token if needed>"}
+    }
+  ],
+  "context": {
+    "source": "claude-code",
+    "original_prompt": "<the user's original request>",
+    "action": "<what the user wants done when condition is met>"
+  }
+}
+```
+
+Response includes `id` (task UUID).
+
+The `context.action` field is delivered back in the webhook payload when the condition triggers, so include what the user wants you to do (e.g. "draft a tweet", "send a summary to Slack").
+
+Webhook URLs must use HTTPS. If your endpoint is local, expose it via Tailscale or a reverse proxy with TLS.
+
+### List monitors
+
+```
+GET /tasks
+```
+
+Returns all tasks for the authenticated user.
+
+### Check status
+
+```
+GET /tasks/{task_id}
+```
+
+Returns task details including last execution result.
+
+### Pause a monitor
+
+```
+PATCH /tasks/{task_id}
+Content-Type: application/json
+
+{"state": "paused"}
+```
+
+### Resume a monitor
+
+```
+PATCH /tasks/{task_id}
+Content-Type: application/json
+
+{"state": "active"}
+```
+
+### Delete a monitor
+
+```
+DELETE /tasks/{task_id}
+```
+
+## Incoming webhook payload
+
+When Torale detects the condition is met, it POSTs to the configured webhook URL:
+
+```json
+{
+  "event_type": "task.condition_met",
+  "data": {
+    "task": {
+      "id": "uuid",
+      "name": "Task Name",
+      "search_query": "what was searched",
+      "condition_description": "what triggered"
+    },
+    "execution": {
+      "notification": "Human-readable summary of what was found"
+    },
+    "result": {
+      "answer": "Detailed evidence and analysis",
+      "grounding_sources": [{"url": "...", "title": "..."}]
+    },
+    "context": {
+      "source": "claude-code",
+      "original_prompt": "...",
+      "action": "what the user wanted done"
+    }
+  }
+}
+```
+
+When you receive this webhook, read `data.context.action` to know what the user wants, and use `data.execution.notification` and `data.result` as your source material.
+
+## Examples
+
+User: "Let me know when Apple announces iPhone 17"
+- search_query: "Apple iPhone 17 announcement release date"
+- condition_description: "Apple officially announces iPhone 17 with confirmed release date"
+- context.action: "notify me with the key details"
+
+User: "Watch for when Next.js 15 is released and summarize the changelog"
+- search_query: "Next.js 15 release"
+- condition_description: "Next.js 15 stable version is officially released"
+- context.action: "summarize the changelog and key new features"
+
+User: "Monitor competitor pricing for Acme Widget and alert me if they drop below $50"
+- search_query: "Acme Widget price"
+- condition_description: "Acme Widget price drops below $50"
+- context.action: "alert me with the new price and where to buy"


### PR DESCRIPTION
## Summary

- Add `context` field to tasks for pass-through data in webhook payloads
- Support custom headers in webhook delivery (enables bearer token auth for OpenClaw, etc.)
- Rate limit task creation (10/min) + per-user active task cap (50, configurable)
- Open API key creation to all authenticated users (was developer-only)
- Protect reserved Torale headers from being overridden by custom headers
- Add Claude Code plugin marketplace + skill for Torale API
- Add OpenClaw integration docs

## Test plan

- [ ] Create task with `context` field, verify it appears in webhook payload
- [ ] Create task with webhook notification + custom `Authorization` header, verify header is sent
- [ ] Verify Torale system headers (`X-Torale-Signature`, etc.) cannot be overridden
- [ ] Hit task creation rate limit (>10/min), verify 429 response
- [ ] Create 50+ active tasks, verify cap enforced
- [ ] Create task as paused, verify cap is not enforced
- [ ] Create API key as non-developer user, verify it works
- [ ] Run migration `a7b8c9d0e1f2` on staging
- [ ] Validate plugin.json + marketplace.json structure