### PR TITLE
refactor: type scheduler/notification dicts as Pydantic models

### DIFF
--- a/backend/src/torale/notifications/novu_service.py
+++ b/backend/src/torale/notifications/novu_service.py
@@ -4,6 +4,8 @@ import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+from pydantic import BaseModel
+
 from torale.core.config import settings
 
 logger = logging.getLogger(__name__)
@@ -56,6 +58,15 @@ def _format_sources(sources: list[dict], limit: int = 5) -> list[dict]:
     return [{"uri": s.get("url", ""), "title": s.get("title", "Unknown")} for s in sources[:limit]]
 
 
+class NovuTriggerResult(BaseModel):
+    """Result from triggering a Novu workflow."""
+
+    success: bool
+    transaction_id: str | None = None
+    error: str | None = None
+    skipped: bool = False
+
+
 @dataclass
 class NotificationPayload:
     """Shared context for task notification emails."""
@@ -91,10 +102,12 @@ class NovuService:
                 self._enabled = False
                 self._client = None
 
-    async def _trigger(self, workflow_id: str, subscriber_id: str, payload: dict) -> dict:
-        """Trigger a Novu workflow and return result dict."""
+    async def _trigger(
+        self, workflow_id: str, subscriber_id: str, payload: dict
+    ) -> NovuTriggerResult:
+        """Trigger a Novu workflow and return result."""
         if not self._enabled or not self._client:
-            return {"success": False, "error": "Novu not configured", "skipped": True}
+            return NovuTriggerResult(success=False, error="Novu not configured", skipped=True)
 
         try:
             import novu_py
@@ -112,18 +125,18 @@ class NovuService:
                 transaction_id = response.result.transaction_id
 
             logger.info(f"Novu workflow '{workflow_id}' sent to {subscriber_id}: {transaction_id}")
-            return {"success": True, "transaction_id": transaction_id}
+            return NovuTriggerResult(success=True, transaction_id=transaction_id)
 
         except Exception as e:
             logger.error(f"Novu workflow '{workflow_id}' error: {e}")
-            return {"success": False, "error": str(e)}
+            return NovuTriggerResult(success=False, error=str(e))
 
     async def send_condition_met_notification(
         self,
         payload: NotificationPayload,
         execution_id: str,
         confidence: int | None = None,
-    ) -> dict:
+    ) -> NovuTriggerResult:
         """Send notification when monitoring condition is met."""
         return await self._trigger(
             workflow_id=settings.novu_workflow_id,
@@ -142,7 +155,9 @@ class NovuService:
             },
         )
 
-    async def send_verification_email(self, email: str, code: str, user_name: str) -> dict:
+    async def send_verification_email(
+        self, email: str, code: str, user_name: str
+    ) -> NovuTriggerResult:
         """Send email verification code."""
         if not self._enabled or not self._client:
             logger.warning(f"Novu not configured - verification code for {email}: {code}")
@@ -160,7 +175,7 @@ class NovuService:
         self,
         payload: NotificationPayload,
         first_execution_result: dict | None,
-    ) -> dict:
+    ) -> NovuTriggerResult:
         """Send welcome email after task creation with first execution results."""
         answer_html = None
         if first_execution_result:

--- a/backend/src/torale/notifications/webhook.py
+++ b/backend/src/torale/notifications/webhook.py
@@ -1,16 +1,21 @@
 """Webhook delivery service with HMAC signing and retry logic."""
 
+from __future__ import annotations
+
 import hashlib
 import hmac
 import secrets
 import time
 from datetime import datetime, timedelta
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import httpx
 from pydantic import BaseModel
 
 from torale.utils.jsonb import parse_jsonb
+
+if TYPE_CHECKING:
+    from torale.scheduler.models import EnrichedExecutionResult
 
 
 class WebhookPayload(BaseModel):
@@ -165,7 +170,7 @@ class WebhookDeliveryService:
 
 
 def build_webhook_payload(
-    execution_id: str, task: dict, execution: dict, result: dict
+    execution_id: str, task: dict, execution: dict, result: EnrichedExecutionResult
 ) -> WebhookPayload:
     """
     Build standardized webhook payload.
@@ -174,13 +179,11 @@ def build_webhook_payload(
         execution_id: Execution ID
         task: Task database record
         execution: Execution database record
-        result: MonitoringResult dict with summary, sources, metadata
+        result: Enriched execution result with summary, sources, notification
 
     Returns:
         WebhookPayload with standardized structure
     """
-    notification_text = result.get("notification", "")
-
     data = {
         "task": {
             "id": str(task["id"]),
@@ -190,12 +193,12 @@ def build_webhook_payload(
         },
         "execution": {
             "id": execution_id,
-            "notification": notification_text,
+            "notification": result.notification or "",
             "completed_at": str(execution.get("completed_at", "")),
         },
         "result": {
-            "answer": result.get("summary", ""),
-            "grounding_sources": result.get("sources", []),
+            "answer": result.summary,
+            "grounding_sources": [s.model_dump() for s in result.sources],
         },
     }
 

--- a/backend/src/torale/scheduler/activities.py
+++ b/backend/src/torale/scheduler/activities.py
@@ -17,6 +17,11 @@ from torale.notifications import (
 )
 from torale.notifications.novu_service import NotificationPayload
 from torale.scheduler.history import ExecutionRecord
+from torale.scheduler.models import (
+    AgentExecutionResult,
+    EnrichedExecutionResult,
+    NotificationContext,
+)
 from torale.tasks import NotificationConfig, TaskStatus
 
 logger = logging.getLogger(__name__)
@@ -46,7 +51,9 @@ async def create_execution_record(task_id: str) -> str:
     return execution_id
 
 
-async def persist_execution_result(task_id: str, execution_id: str, agent_result: dict) -> None:
+async def persist_execution_result(
+    task_id: str, execution_id: str, agent_result: AgentExecutionResult
+) -> None:
     """Persist agent execution result to database.
 
     Maps agent response fields:
@@ -56,10 +63,9 @@ async def persist_execution_result(task_id: str, execution_id: str, agent_result
     """
     now_utc = datetime.now(UTC)
 
-    notification_text = agent_result.get("notification")
-    grounding_sources = agent_result.get("grounding_sources", [])
-    evidence = agent_result.get("evidence", "")
+    evidence = agent_result.evidence
     last_known_state = {"evidence": evidence} if evidence else None
+    grounding_sources_json = json.dumps([s.model_dump() for s in agent_result.grounding_sources])
 
     async with db.acquire() as conn:
         async with conn.transaction():
@@ -71,10 +77,10 @@ async def persist_execution_result(task_id: str, execution_id: str, agent_result
                 WHERE id = $6
                 """,
                 TaskStatus.SUCCESS.value,
-                json.dumps(agent_result),
+                agent_result.model_dump_json(),
                 now_utc,
-                notification_text,
-                json.dumps(grounding_sources),
+                agent_result.notification,
+                grounding_sources_json,
                 UUID(execution_id),
             )
 
@@ -93,7 +99,9 @@ async def persist_execution_result(task_id: str, execution_id: str, agent_result
             )
 
 
-async def fetch_notification_context(task_id: str, execution_id: str, user_id: str) -> dict:
+async def fetch_notification_context(
+    task_id: str, execution_id: str, user_id: str
+) -> NotificationContext:
     """Fetch notification context: task, user, execution details."""
     task = await db.fetch_one(
         """
@@ -129,36 +137,37 @@ async def fetch_notification_context(task_id: str, execution_id: str, user_id: s
             webhook_headers = notif.headers
             break
 
-    return {
-        "task": dict(task),
-        "execution": dict(execution),
-        "clerk_email": task["clerk_email"],
-        "verified_emails": task["verified_notification_emails"] or [],
-        "notification_channels": task.get("notification_channels") or ["email"],
-        "webhook_url": task.get("webhook_url") or task.get("user_webhook_url"),
-        "webhook_secret": task.get("webhook_secret") or task.get("user_webhook_secret"),
-        "webhook_headers": webhook_headers,
-    }
+    return NotificationContext(
+        task=dict(task),
+        execution=dict(execution),
+        clerk_email=task["clerk_email"],
+        verified_emails=task["verified_notification_emails"] or [],
+        notification_channels=task.get("notification_channels") or ["email"],
+        webhook_url=task.get("webhook_url") or task.get("user_webhook_url"),
+        webhook_secret=task.get("webhook_secret") or task.get("user_webhook_secret"),
+        webhook_headers=webhook_headers,
+    )
 
 
 async def send_email_notification(
-    user_id: str, task_name: str, notification_context: dict, result: dict
+    user_id: str,
+    task_name: str,
+    notification_context: NotificationContext,
+    result: EnrichedExecutionResult,
 ) -> bool:
     """Send email notification (welcome or condition met).
 
     Returns True if delivered, False if skipped (e.g. Novu not configured).
     Raises on failure.
     """
-    task = notification_context["task"]
+    task = notification_context.task
     task_id = str(task["id"])
-    execution_id = result.get("execution_id")
-    if not execution_id:
-        raise RuntimeError("execution_id required for email notifications")
-    clerk_email = notification_context["clerk_email"]
-    verified_emails = notification_context["verified_emails"]
-    is_first_execution = result.get("is_first_execution", False)
+    execution_id = result.execution_id
+    clerk_email = notification_context.clerk_email
+    verified_emails = notification_context.verified_emails
+    sources_as_dicts = [s.model_dump() for s in result.sources]
 
-    if is_first_execution:
+    if result.is_first_execution:
         logger.info(f"Sending welcome email for task {task_id}")
 
         notification_payload = NotificationPayload(
@@ -168,14 +177,14 @@ async def send_email_notification(
             answer="",
             grounding_sources=[],
             task_id=str(task_id),
-            next_run=result.get("next_run"),
+            next_run=result.next_run,
         )
         await novu_service.send_welcome_email(
             payload=notification_payload,
             first_execution_result={
-                "answer": result.get("summary", ""),
-                "condition_met": result.get("notification") is not None,
-                "grounding_sources": result.get("sources", []),
+                "answer": result.summary,
+                "condition_met": result.notification is not None,
+                "grounding_sources": sources_as_dicts,
             },
         )
         logger.info(f"Welcome email sent for task {task_id}")
@@ -201,36 +210,33 @@ async def send_email_notification(
         raise RuntimeError(f"Spam limit exceeded: {error}")
 
     # Send email via Novu
-    answer = result.get("summary", "")
-    sources = result.get("sources", [])
-
     notification_payload = NotificationPayload(
         subscriber_id=recipient_email,
         task_name=task_name,
         search_query=task.get("search_query", ""),
-        answer=answer,
-        grounding_sources=sources,
+        answer=result.summary,
+        grounding_sources=sources_as_dicts,
         task_id=str(task_id),
-        next_run=result.get("next_run"),
+        next_run=result.next_run,
     )
     novu_result = await novu_service.send_condition_met_notification(
         payload=notification_payload,
         execution_id=execution_id,
-        confidence=result.get("confidence"),
+        confidence=result.confidence,
     )
 
     email_status = "success"
     email_error = None
 
-    if novu_result["success"]:
+    if novu_result.success:
         logger.info(f"Email sent for task {task_id}")
-    elif novu_result.get("skipped"):
+    elif novu_result.skipped:
         logger.info("Email notification skipped (Novu not configured)")
         email_status = "skipped"
     else:
-        logger.error(f"Failed to send email for task {task_id}: {novu_result.get('error')}")
+        logger.error(f"Failed to send email for task {task_id}: {novu_result.error}")
         email_status = "failed"
-        email_error = str(novu_result.get("error"))
+        email_error = str(novu_result.error)
 
     await db.execute(
         """
@@ -252,17 +258,17 @@ async def send_email_notification(
     return email_status == "success"
 
 
-async def send_webhook_notification(notification_context: dict, result: dict) -> None:
+async def send_webhook_notification(
+    notification_context: NotificationContext, result: EnrichedExecutionResult
+) -> None:
     """Send webhook notification."""
-    task = notification_context["task"]
-    execution = notification_context["execution"]
+    task = notification_context.task
+    execution = notification_context.execution
     task_id = str(task["id"])
-    execution_id = result.get("execution_id")
-    if not execution_id:
-        raise RuntimeError("execution_id required for webhook notifications")
+    execution_id = result.execution_id
 
-    webhook_url = notification_context.get("webhook_url")
-    webhook_secret = notification_context.get("webhook_secret")
+    webhook_url = notification_context.webhook_url
+    webhook_secret = notification_context.webhook_secret
 
     if not webhook_url or not webhook_secret:
         raise RuntimeError("Webhook URL or secret not configured")
@@ -277,7 +283,7 @@ async def send_webhook_notification(notification_context: dict, result: dict) ->
             payload,
             webhook_secret,
             attempt=1,
-            custom_headers=notification_context["webhook_headers"],
+            custom_headers=notification_context.webhook_headers,
         )
     finally:
         await service.close()

--- a/backend/src/torale/scheduler/job.py
+++ b/backend/src/torale/scheduler/job.py
@@ -32,7 +32,12 @@ from torale.scheduler.errors import (
     should_retry,
 )
 from torale.scheduler.history import format_execution_history
-from torale.scheduler.models import MonitoringResponse
+from torale.scheduler.models import (
+    AgentExecutionResult,
+    EnrichedExecutionResult,
+    GroundingSource,
+    MonitoringResponse,
+)
 from torale.scheduler.prompt_sanitizer import PromptSanitizer
 from torale.scheduler.scheduler import get_scheduler
 from torale.tasks import TaskState, TaskStatus
@@ -211,20 +216,21 @@ async def _execute(
         next_run_dt = _parse_next_run(next_run_value)
         next_run = next_run_dt.isoformat() if next_run_dt else None
 
-        grounding_sources = [{"url": u, "title": urlparse(u).netloc or u} for u in sources]
+        grounding_sources = [GroundingSource(url=u, title=urlparse(u).netloc or u) for u in sources]
 
         activity = agent_response.activity
+        agent_exec_result = AgentExecutionResult(
+            evidence=evidence,
+            notification=notification,
+            confidence=confidence,
+            next_run=next_run,
+            grounding_sources=grounding_sources,
+            activity=[s.model_dump() for s in activity] if activity else None,
+        )
         await persist_execution_result(
             task_id=task_id,
             execution_id=execution_id,
-            agent_result={
-                "evidence": evidence,
-                "notification": notification,
-                "confidence": confidence,
-                "next_run": next_run,
-                "grounding_sources": grounding_sources,
-                "activity": [s.model_dump() for s in activity] if activity else None,
-            },
+            agent_result=agent_exec_result,
         )
 
         # Send notifications if notification text present
@@ -235,7 +241,7 @@ async def _execute(
                     task_id, execution_id, user_id
                 )
 
-                channels = notification_context.get("notification_channels", ["email"])
+                channels = notification_context.notification_channels
 
                 execution_count = await db.fetch_val(
                     "SELECT COUNT(*) FROM task_executions WHERE task_id = $1 AND status = $2",
@@ -243,15 +249,15 @@ async def _execute(
                     TaskStatus.SUCCESS.value,
                 )
 
-                enriched_result = {
-                    "execution_id": execution_id,
-                    "summary": notification or evidence,
-                    "sources": grounding_sources,
-                    "notification": notification,
-                    "is_first_execution": execution_count == 1,
-                    "next_run": next_run,
-                    "confidence": confidence,
-                }
+                enriched_result = EnrichedExecutionResult(
+                    execution_id=execution_id,
+                    summary=notification or evidence,
+                    sources=grounding_sources,
+                    notification=notification,
+                    is_first_execution=execution_count == 1,
+                    next_run=next_run,
+                    confidence=confidence,
+                )
 
                 if "email" in channels:
                     email_delivered = await send_email_notification(

--- a/backend/src/torale/scheduler/job.py
+++ b/backend/src/torale/scheduler/job.py
@@ -225,7 +225,7 @@ async def _execute(
             confidence=confidence,
             next_run=next_run,
             grounding_sources=grounding_sources,
-            activity=[s.model_dump() for s in activity] if activity else None,
+            activity=activity,
         )
         await persist_execution_result(
             task_id=task_id,

--- a/backend/src/torale/scheduler/models.py
+++ b/backend/src/torale/scheduler/models.py
@@ -3,6 +3,49 @@
 from pydantic import BaseModel, Field
 
 
+class GroundingSource(BaseModel):
+    """A URL source backing agent evidence."""
+
+    url: str
+    title: str
+
+
+class NotificationContext(BaseModel):
+    """Typed context for notification delivery, built from task + user + execution data."""
+
+    task: dict
+    execution: dict
+    clerk_email: str
+    verified_emails: list[str] = []
+    notification_channels: list[str] = Field(default_factory=lambda: ["email"])
+    webhook_url: str | None = None
+    webhook_secret: str | None = None
+    webhook_headers: dict[str, str] | None = None
+
+
+class AgentExecutionResult(BaseModel):
+    """Agent output persisted to DB. Constructed in job.py, consumed by persist_execution_result."""
+
+    evidence: str
+    notification: str | None = None
+    confidence: int
+    next_run: str | None = None
+    grounding_sources: list[GroundingSource] = []
+    activity: list[dict] | None = None
+
+
+class EnrichedExecutionResult(BaseModel):
+    """Execution result enriched with notification metadata for delivery functions."""
+
+    execution_id: str
+    summary: str
+    sources: list[GroundingSource] = []
+    notification: str | None = None
+    is_first_execution: bool = False
+    next_run: str | None = None
+    confidence: int | None = None
+
+
 class ActivityStep(BaseModel):
     """A single step the agent took during monitoring."""
 

--- a/backend/src/torale/scheduler/models.py
+++ b/backend/src/torale/scheduler/models.py
@@ -31,7 +31,7 @@ class AgentExecutionResult(BaseModel):
     confidence: int
     next_run: str | None = None
     grounding_sources: list[GroundingSource] = []
-    activity: list[dict] | None = None
+    activity: list["ActivityStep"] | None = None
 
 
 class EnrichedExecutionResult(BaseModel):

--- a/backend/tests/test_activities.py
+++ b/backend/tests/test_activities.py
@@ -8,6 +8,8 @@ from uuid import uuid4
 
 import pytest
 
+from torale.scheduler.models import AgentExecutionResult, GroundingSource
+
 MODULE = "torale.scheduler.activities"
 
 TASK_ID = str(uuid4())
@@ -15,13 +17,13 @@ EXECUTION_ID = str(uuid4())
 
 
 def _make_agent_result():
-    return {
-        "evidence": "No changes detected",
-        "notification": None,
-        "confidence": "high",
-        "next_run": None,
-        "grounding_sources": [{"url": "https://example.com"}],
-    }
+    return AgentExecutionResult(
+        evidence="No changes detected",
+        notification=None,
+        confidence=80,
+        next_run=None,
+        grounding_sources=[GroundingSource(url="https://example.com", title="example.com")],
+    )
 
 
 def _setup_db_mock(mock_db):
@@ -66,10 +68,12 @@ class TestPersistExecutionResult:
         """evidence -> last_known_state, notification/grounding_sources mapped."""
         mock_conn = _setup_db_mock(mock_db)
 
-        agent_result = _make_agent_result()
-        agent_result["evidence"] = "Price is $999"
-        agent_result["notification"] = "Price dropped!"
-        agent_result["grounding_sources"] = [{"url": "https://apple.com"}]
+        agent_result = AgentExecutionResult(
+            evidence="Price is $999",
+            notification="Price dropped!",
+            confidence=90,
+            grounding_sources=[GroundingSource(url="https://apple.com", title="Apple")],
+        )
 
         from torale.scheduler.activities import persist_execution_result
 
@@ -78,7 +82,7 @@ class TestPersistExecutionResult:
         exec_call = mock_conn.execute.call_args_list[0]
         exec_args = exec_call[0]
         assert exec_args[4] == "Price dropped!"  # notification
-        assert json.loads(exec_args[5]) == [{"url": "https://apple.com"}]
+        assert json.loads(exec_args[5]) == [{"url": "https://apple.com", "title": "Apple"}]
 
         task_call = mock_conn.execute.call_args_list[1]
         task_args = task_call[0]

--- a/backend/tests/test_job.py
+++ b/backend/tests/test_job.py
@@ -12,7 +12,7 @@ import pytest
 
 from torale.scheduler.history import ExecutionRecord
 from torale.scheduler.job import _execute, execute_task_job
-from torale.scheduler.models import MonitoringResponse
+from torale.scheduler.models import MonitoringResponse, NotificationContext
 
 TASK_ID = str(uuid4())
 EXECUTION_ID = str(uuid4())
@@ -32,6 +32,15 @@ def _make_task_row():
         "notification_channels": ["email"],
         "state": "active",
     }
+
+
+def _make_notification_context(channels=None):
+    return NotificationContext(
+        task={"id": TASK_ID, "name": TASK_NAME},
+        execution={"id": EXECUTION_ID},
+        clerk_email="test@example.com",
+        notification_channels=channels or ["email"],
+    )
 
 
 def _make_agent_response(notification=None, evidence="no changes", next_run=FUTURE):
@@ -65,7 +74,7 @@ class TestExecute:
         job_mocks.agent.return_value = _make_agent_response(
             notification="Release date is Sept 9", next_run=None
         )
-        job_mocks.fetch_ctx.return_value = {"notification_channels": ["email"]}
+        job_mocks.fetch_ctx.return_value = _make_notification_context()
         job_mocks.email.return_value = True
 
         mock_service = MagicMock()
@@ -82,7 +91,7 @@ class TestExecute:
         """Agent returns next_run -> notification sent, NOT completed."""
         job_mocks.db.fetch_one = AsyncMock(return_value=_make_task_row())
         job_mocks.agent.return_value = _make_agent_response(notification="Price dropped")
-        job_mocks.fetch_ctx.return_value = {"notification_channels": ["email"]}
+        job_mocks.fetch_ctx.return_value = _make_notification_context()
         job_mocks.email.return_value = True
 
         await _execute(TASK_ID, EXECUTION_ID, USER_ID, TASK_NAME)
@@ -95,7 +104,7 @@ class TestExecute:
         """Notification raises -> execution still succeeds, next run still scheduled."""
         job_mocks.db.fetch_one = AsyncMock(return_value=_make_task_row())
         job_mocks.agent.return_value = _make_agent_response(notification="Condition met")
-        job_mocks.fetch_ctx.return_value = {"notification_channels": ["email"]}
+        job_mocks.fetch_ctx.return_value = _make_notification_context()
         job_mocks.email.side_effect = RuntimeError("SMTP error")
 
         mock_sched = MagicMock()
@@ -113,7 +122,7 @@ class TestExecute:
         job_mocks.agent.return_value = _make_agent_response(
             notification="Condition met", next_run=None
         )
-        job_mocks.fetch_ctx.return_value = {"notification_channels": ["email"]}
+        job_mocks.fetch_ctx.return_value = _make_notification_context()
         job_mocks.email.side_effect = RuntimeError("SMTP error")
 
         mock_service = MagicMock()
@@ -295,14 +304,14 @@ class TestExecute:
         """First successful execution -> is_first_execution=True in enriched_result."""
         job_mocks.db.fetch_one = AsyncMock(return_value=_make_task_row())
         job_mocks.agent.return_value = _make_agent_response(notification="Condition met")
-        job_mocks.fetch_ctx.return_value = {"notification_channels": ["email"]}
+        job_mocks.fetch_ctx.return_value = _make_notification_context()
         job_mocks.email.return_value = True
         job_mocks.db.fetch_val = AsyncMock(return_value=1)
 
         await _execute(TASK_ID, EXECUTION_ID, USER_ID, TASK_NAME)
 
         enriched_result = job_mocks.email.call_args[0][3]
-        assert enriched_result["is_first_execution"] is True
+        assert enriched_result.is_first_execution is True
 
     @pytest.mark.asyncio
     async def test_first_run_no_history(self, job_mocks):

--- a/backend/tests/test_webhook.py
+++ b/backend/tests/test_webhook.py
@@ -13,20 +13,17 @@ from torale.notifications import (
     WebhookSignature,
     build_webhook_payload,
 )
+from torale.scheduler.models import EnrichedExecutionResult, GroundingSource
 
 
 @pytest.fixture
 def sample_monitoring_result():
-    """Create MonitoringResult dict (new structure)."""
-    return {
-        "summary": "Test answer",
-        "sources": [{"uri": "https://example.com", "title": "Example"}],
-        "metadata": {
-            "changed": True,
-            "change_explanation": "Test change",
-            "current_state": {"test_field": "test_value"},
-        },
-    }
+    """Create EnrichedExecutionResult for webhook tests."""
+    return EnrichedExecutionResult(
+        execution_id="test-exec-id",
+        summary="Test answer",
+        sources=[GroundingSource(url="https://example.com", title="Example")],
+    )
 
 
 class TestWebhookSignature:
@@ -170,7 +167,7 @@ class TestBuildWebhookPayload:
 
         exec_data = payload.data["execution"]
         assert exec_data["id"] == str(sample_execution.id)
-        assert exec_data["notification"] == sample_monitoring_result.get("notification", "")
+        assert exec_data["notification"] == (sample_monitoring_result.notification or "")
 
 
 class TestWebhookDeliveryService:


### PR DESCRIPTION
## Summary

Closes #209

- Add 5 Pydantic models (`GroundingSource`, `NotificationContext`, `AgentExecutionResult`, `EnrichedExecutionResult`, `NovuTriggerResult`) replacing raw `dict` params that cross function boundaries in the scheduler/notification pipeline
- Update all producers (job.py) to construct typed models and all consumers (activities.py, webhook.py, novu_service.py) to use attribute access instead of string-key lookups
- Update tests to construct models instead of dicts

## Test plan

- [x] `just lint` passes (ruff check + format)
- [x] `just test` passes (226 passed, 0 failures)
- [x] Grep confirms zero remaining dict access (`[key]` / `.get()`) on refactored objects in `src/`