### PR TITLE
fix: parse context JSONB as object in webhook payload

### DIFF
--- a/backend/src/torale/notifications/webhook.py
+++ b/backend/src/torale/notifications/webhook.py
@@ -10,6 +10,8 @@ from typing import Literal
 import httpx
 from pydantic import BaseModel
 
+from torale.utils.jsonb import parse_jsonb
+
 
 class WebhookPayload(BaseModel):
     """Standard webhook payload format (inspired by Stripe/GitHub)."""
@@ -197,7 +199,7 @@ def build_webhook_payload(
         },
     }
 
-    task_context = task.get("context")
+    task_context = parse_jsonb(task.get("context"), "context", dict, None)
     if task_context:
         data["context"] = task_context
 


### PR DESCRIPTION
## Summary

The `context` field in webhook payloads was delivered as a JSON string instead of a parsed object. The `databases` library returns JSONB columns as strings (same issue as `notifications` column, which already has `json.loads()` at `activities.py:125`). Consumers had to `JSON.parse()` the context field to use it.

Fix: `json.loads()` the context if it comes back as a string, pass through if already a dict.

## Test plan

- [x] 14 webhook tests pass
- [ ] Post-deploy: create a task with context, trigger execution, verify webhook payload has `"context": {...}` not `"context": "{...}"`