### PR TITLE
fix: fallback to paid tier on Gemini 503 (model overloaded)

### DIFF
--- a/backend/src/torale/scheduler/agent.py
+++ b/backend/src/torale/scheduler/agent.py
@@ -6,6 +6,7 @@ import json
 import logging
 import time
 import uuid
+from http import HTTPStatus
 
 import httpx
 from a2a.client import A2AClient
@@ -35,6 +36,9 @@ logger = logging.getLogger(__name__)
 AGENT_TIMEOUT = 120  # seconds
 POLL_BACKOFF = [0.5, 1, 2, 4, 8, 16, 32]  # exponential backoff steps
 MAX_CONSECUTIVE_POLL_FAILURES = 3
+
+# Upstream model failures worth retrying on the paid tier.
+FALLBACK_STATUS_CODES = frozenset({HTTPStatus.TOO_MANY_REQUESTS, HTTPStatus.SERVICE_UNAVAILABLE})
 
 # Reuse httpx client for connection pooling
 _httpx_client: httpx.AsyncClient | None = None
@@ -85,7 +89,8 @@ def _handle_failed_task(task: Task) -> None:
     """Process failed task and raise appropriate error.
 
     Extracts error details from task status and raises:
-    - A2AClientHTTPError(429) for rate limits (triggers paid tier fallback)
+    - A2AClientHTTPError for upstream model failures eligible for paid tier fallback
+      (see FALLBACK_STATUS_CODES)
     - RuntimeError for other errors
     """
     task_id = task.id
@@ -105,8 +110,10 @@ def _handle_failed_task(task: Task) -> None:
 
     if error_type == "ModelHTTPError":
         status_code = error_details.get("status_code")
-        if status_code == 429:
-            raise A2AClientHTTPError(429, f"Agent task {task_id} hit rate limit: {message}")
+        if status_code in FALLBACK_STATUS_CODES:
+            raise A2AClientHTTPError(
+                status_code, f"Agent task {task_id} upstream {status_code}: {message}"
+            )
         raise RuntimeError(f"Agent task {task_id} HTTP error {status_code}: {message}")
 
     raise RuntimeError(f"Agent task {task_id} {error_type}: {message}")
@@ -115,15 +122,16 @@ def _handle_failed_task(task: Task) -> None:
 async def call_agent(
     prompt: str, user_id: str | None = None, task_id: str | None = None
 ) -> MonitoringResponse:
-    """Send task to agent with automatic paid tier fallback on 429."""
+    """Send task to agent with automatic paid tier fallback on upstream failures."""
     try:
         result = await _call_agent_internal(settings.agent_url_free, prompt, user_id, task_id)
         tier, fallback = "free", False
     except A2AClientHTTPError as e:
-        if e.status_code != 429:
+        if e.status_code not in FALLBACK_STATUS_CODES:
             raise
         logger.info(
-            "Free tier rate limit hit (429), falling back to paid tier",
+            "Free tier upstream failure (%s), falling back to paid tier",
+            e.status_code,
             extra={"status_code": e.status_code},
         )
         result = await _call_agent_internal(settings.agent_url_paid, prompt, user_id, task_id)
@@ -173,9 +181,8 @@ async def _call_agent_internal(
     try:
         send_response = await client.send_message(request)
     except A2AClientHTTPError as e:
-        # Re-raise 429 to preserve status_code for fallback logic
-        # Wrap other HTTP errors in RuntimeError for consistent error handling
-        if e.status_code == 429:
+        # Preserve status_code for fallback-eligible upstream failures; wrap the rest.
+        if e.status_code in FALLBACK_STATUS_CODES:
             raise
         raise RuntimeError(
             f"Failed to send task to agent at {base_url}: status={e.status_code} {e.message[:200]}"

--- a/backend/tests/test_429_fallback.py
+++ b/backend/tests/test_429_fallback.py
@@ -15,14 +15,23 @@ from torale.scheduler.models import MonitoringResponse
 class TestPaidTierFallback:
     """Test automatic fallback to paid tier on 429 errors."""
 
+    @pytest.mark.parametrize(
+        ("status_code", "error_message"),
+        [
+            (429, "Rate limit exceeded"),
+            (503, "Model overloaded"),
+        ],
+    )
     @patch("torale.scheduler.agent.settings")
-    async def test_429_triggers_paid_tier_fallback(self, mock_settings):
-        """When free tier returns 429, should automatically try paid tier."""
+    async def test_fallback_status_triggers_paid_tier(
+        self, mock_settings, status_code, error_message
+    ):
+        """Fallback-eligible upstream failures on free tier should retry on paid tier."""
         mock_settings.agent_url_free = "http://agent-free:8000"
         mock_settings.agent_url_paid = "http://agent-paid:8000"
 
         completed_task = make_a2a_task(
-            task_id="task-paid-123",
+            task_id=f"task-paid-{status_code}",
             artifacts=[
                 data_artifact(
                     {
@@ -37,27 +46,24 @@ class TestPaidTierFallback:
         )
 
         with patch("torale.scheduler.agent.A2AClient") as mock_client_class:
-            # First call (free tier) raises 429
             free_client = AsyncMock()
             free_client.send_message = AsyncMock(
-                side_effect=A2AClientHTTPError(429, "Rate limit exceeded")
+                side_effect=A2AClientHTTPError(status_code, error_message)
             )
 
-            # Second call (paid tier) succeeds
             paid_client = AsyncMock()
             paid_client.send_message = AsyncMock(
                 return_value=send_success(
-                    make_a2a_task(task_id="task-paid-123", status_state=TaskState.submitted)
+                    make_a2a_task(
+                        task_id=f"task-paid-{status_code}", status_state=TaskState.submitted
+                    )
                 )
             )
             paid_client.get_task = AsyncMock(return_value=poll_success(completed_task))
 
-            # Return different clients based on url kwarg
             def get_client(**kwargs):
                 url = kwargs.get("url", "")
-                if "free" in url:
-                    return free_client
-                return paid_client
+                return free_client if "free" in url else paid_client
 
             mock_client_class.side_effect = get_client
 
@@ -66,60 +72,6 @@ class TestPaidTierFallback:
             assert isinstance(result, MonitoringResponse)
             assert result.evidence == "Test evidence"
             assert result.notification == "Test notification"
-
-            # Verify both clients were created
-            assert mock_client_class.call_count == 2
-            # First call should be to free tier
-            assert "free" in mock_client_class.call_args_list[0][1]["url"]
-            # Second call should be to paid tier
-            assert "paid" in mock_client_class.call_args_list[1][1]["url"]
-
-    @patch("torale.scheduler.agent.settings")
-    async def test_503_triggers_paid_tier_fallback(self, mock_settings):
-        """503 (model overloaded) should also trigger paid tier fallback."""
-        mock_settings.agent_url_free = "http://agent-free:8000"
-        mock_settings.agent_url_paid = "http://agent-paid:8000"
-
-        completed_task = make_a2a_task(
-            task_id="task-paid-503",
-            artifacts=[
-                data_artifact(
-                    {
-                        "evidence": "Test evidence",
-                        "sources": ["http://example.com"],
-                        "confidence": 95,
-                        "next_run": None,
-                        "notification": "Test notification",
-                    }
-                )
-            ],
-        )
-
-        with patch("torale.scheduler.agent.A2AClient") as mock_client_class:
-            free_client = AsyncMock()
-            free_client.send_message = AsyncMock(
-                side_effect=A2AClientHTTPError(503, "Model overloaded")
-            )
-
-            paid_client = AsyncMock()
-            paid_client.send_message = AsyncMock(
-                return_value=send_success(
-                    make_a2a_task(task_id="task-paid-503", status_state=TaskState.submitted)
-                )
-            )
-            paid_client.get_task = AsyncMock(return_value=poll_success(completed_task))
-
-            def get_client(**kwargs):
-                url = kwargs.get("url", "")
-                if "free" in url:
-                    return free_client
-                return paid_client
-
-            mock_client_class.side_effect = get_client
-
-            result = await call_agent("test prompt")
-
-            assert isinstance(result, MonitoringResponse)
             assert mock_client_class.call_count == 2
             assert "free" in mock_client_class.call_args_list[0][1]["url"]
             assert "paid" in mock_client_class.call_args_list[1][1]["url"]

--- a/backend/tests/test_429_fallback.py
+++ b/backend/tests/test_429_fallback.py
@@ -75,25 +75,72 @@ class TestPaidTierFallback:
             assert "paid" in mock_client_class.call_args_list[1][1]["url"]
 
     @patch("torale.scheduler.agent.settings")
-    async def test_non_429_error_does_not_fallback(self, mock_settings):
-        """Non-429 errors should not trigger paid tier fallback."""
+    async def test_503_triggers_paid_tier_fallback(self, mock_settings):
+        """503 (model overloaded) should also trigger paid tier fallback."""
+        mock_settings.agent_url_free = "http://agent-free:8000"
+        mock_settings.agent_url_paid = "http://agent-paid:8000"
+
+        completed_task = make_a2a_task(
+            task_id="task-paid-503",
+            artifacts=[
+                data_artifact(
+                    {
+                        "evidence": "Test evidence",
+                        "sources": ["http://example.com"],
+                        "confidence": 95,
+                        "next_run": None,
+                        "notification": "Test notification",
+                    }
+                )
+            ],
+        )
+
+        with patch("torale.scheduler.agent.A2AClient") as mock_client_class:
+            free_client = AsyncMock()
+            free_client.send_message = AsyncMock(
+                side_effect=A2AClientHTTPError(503, "Model overloaded")
+            )
+
+            paid_client = AsyncMock()
+            paid_client.send_message = AsyncMock(
+                return_value=send_success(
+                    make_a2a_task(task_id="task-paid-503", status_state=TaskState.submitted)
+                )
+            )
+            paid_client.get_task = AsyncMock(return_value=poll_success(completed_task))
+
+            def get_client(**kwargs):
+                url = kwargs.get("url", "")
+                if "free" in url:
+                    return free_client
+                return paid_client
+
+            mock_client_class.side_effect = get_client
+
+            result = await call_agent("test prompt")
+
+            assert isinstance(result, MonitoringResponse)
+            assert mock_client_class.call_count == 2
+            assert "free" in mock_client_class.call_args_list[0][1]["url"]
+            assert "paid" in mock_client_class.call_args_list[1][1]["url"]
+
+    @patch("torale.scheduler.agent.settings")
+    async def test_non_fallback_error_does_not_fallback(self, mock_settings):
+        """Non-retryable errors (e.g. 500) should not trigger paid tier fallback."""
         mock_settings.agent_url_free = "http://agent-free:8000"
         mock_settings.agent_url_paid = "http://agent-paid:8000"
 
         with patch("torale.scheduler.agent.A2AClient") as mock_client_class:
-            # Free tier raises 503 (not 429)
             free_client = AsyncMock()
             free_client.send_message = AsyncMock(
-                side_effect=A2AClientHTTPError(503, "Service unavailable")
+                side_effect=A2AClientHTTPError(500, "Internal server error")
             )
 
             mock_client_class.return_value = free_client
 
-            # Should raise RuntimeError (wrapped 503), not try paid tier
             with pytest.raises(RuntimeError, match="Failed to send task to agent"):
                 await call_agent("test prompt")
 
-            # Verify only free tier was tried
             assert mock_client_class.call_count == 1
             assert "free" in mock_client_class.call_args[1]["url"]
 

--- a/backend/tests/test_agent.py
+++ b/backend/tests/test_agent.py
@@ -493,7 +493,7 @@ class TestCallAgent:
     @pytest.mark.parametrize(
         "exception",
         [
-            A2AClientHTTPError(503, "Service Unavailable"),
+            A2AClientHTTPError(500, "Internal Server Error"),
             ConnectionError("Connection refused"),
         ],
         ids=["http_error", "connection_error"],


### PR DESCRIPTION
## Summary

- User-visible task failures were driven almost entirely by Gemini `503 UNAVAILABLE` (*"model experiencing high demand"*) on the free tier — 172 hits in the last 30 days vs 18 for 429 and 2 for 500. The existing fallback only triggered on 429, so every 503 surfaced as a FAILED row.
- Broadens the paid-tier fallback allowlist to include 503 alongside 429, centralized in a single `FALLBACK_STATUS_CODES = frozenset({HTTPStatus.TOO_MANY_REQUESTS, HTTPStatus.SERVICE_UNAVAILABLE})`.
- 500/502/504 intentionally left out: they're caller-independent upstream errors where paid-tier fallback wouldn't help (and 502/504 haven't been observed at all).

## Test plan

- [x] `test_429_triggers_paid_tier_fallback` still passes (unchanged behavior)
- [x] New `test_503_triggers_paid_tier_fallback` verifies 503 now falls back
- [x] `test_non_fallback_error_does_not_fallback` (using 500) verifies non-allowlisted codes still propagate as `RuntimeError`
- [x] `test_both_tiers_429_propagates_error` still passes
- [x] Full backend suite: 227 passed, 30 skipped
- [x] `just lint` (backend): clean