### PR TITLE
feat(helm): add webwhen.ai parallel HTTPRoutes with soak overlay

### DIFF
--- a/helm/torale/templates/httproute.yaml
+++ b/helm/torale/templates/httproute.yaml
@@ -148,4 +148,285 @@ spec:
       port: {{ .Values.docs.service.port }}
       weight: 1
 {{- end }}
+
+# ============================================================================
+# webwhen.ai parallel routes (rebrand cutover)
+# ----------------------------------------------------------------------------
+# These render only when .Values.domains.webwhen is set (soak overlay or
+# cutover values). Until then the chart deploys the torale.ai routes only.
+#
+# During the soak window (T-2d → T-0): set .Values.httproute.noindex=true to
+# inject `X-Robots-Tag: noindex, nofollow` on every rule via
+# ResponseHeaderModifier. SERP keeps treating webwhen.ai as new while the
+# soak runs; cutover-day diff is removing the soak overlay (or flipping
+# httproute.noindex to false) — no other changes to these routes.
+#
+# Cert: all webwhen hostnames share `webwhen-ai-origin-cert` (Cloudflare
+# Origin CA wildcard, 15-yr) attached to clusterkit-gateway via pre-shared
+# certs annotation. No per-route cert reference needed; the gateway listener
+# owns it.
+#
+# Hostnames covered (production release):
+#   webwhen.ai           → frontend catchall + 4 SEO routes to api
+#   www.webwhen.ai       → 301 redirect to apex (RequestRedirect filter)
+#   api.webwhen.ai       → backend api catchall
+#   docs.webwhen.ai      → docs catchall (gated on .Values.docs.enabled)
+#
+# Hostnames covered (staging release):
+#   staging.webwhen.ai     → frontend + SEO split
+#   api-staging.webwhen.ai → backend api catchall
+#
+# The www-redirect renders only on production (no www-staging hostname).
+#
+# OPERATOR GOTCHAS (validated on clusterkit PR #3):
+#
+# 1. ExternalDNS runs `policy: upsert-only`. Records are CREATED on
+#    HTTPRoute apply but NEVER DELETED on HTTPRoute remove. Any time you
+#    delete/rename a webwhen route — mid-validation, after the soak,
+#    during torale.ai sunset — orphan A/TXT records remain in Cloudflare.
+#    You MUST clean them manually via the Cloudflare API. dnsctl helper
+#    in clusterkit/scripts wraps this; see clusterkit/docs for the
+#    recipe.
+#
+# 2. `dig +short hostname @1.1.1.1` is UNRELIABLE for verifying record
+#    absence on Cloudflare-proxied zones. CF nameservers return edge IPs
+#    (188.114.96.0 / 188.114.97.0) for any name in a proxied zone, even
+#    when no record exists. Verify cleanup via Cloudflare API
+#    (`count=0` on the records endpoint), never via dig.
+# ============================================================================
+{{- if .Values.domains.webwhen }}
+---
+# webwhen frontend HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: webwhen-{{ $envPrefix }}main
+  namespace: clusterkit
+  labels:
+    {{- include "torale.labels" . | nindent 4 }}
+    app.kubernetes.io/component: routing
+  annotations:
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.httproute.gatewayName }}
+    namespace: clusterkit
+  hostnames:
+  - {{ .Values.domains.webwhen.frontend | quote }}
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /sitemap.xml
+    {{- if .Values.httproute.noindex }}
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Robots-Tag
+          value: "noindex, nofollow"
+    {{- end }}
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: {{ $fullName }}-api
+      namespace: {{ $serviceNamespace }}
+      port: {{ .Values.api.service.port }}
+      weight: 1
+  - matches:
+    - path:
+        type: Exact
+        value: /sitemap-dynamic.xml
+    {{- if .Values.httproute.noindex }}
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Robots-Tag
+          value: "noindex, nofollow"
+    {{- end }}
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: {{ $fullName }}-api
+      namespace: {{ $serviceNamespace }}
+      port: {{ .Values.api.service.port }}
+      weight: 1
+  - matches:
+    - path:
+        type: Exact
+        value: /changelog.xml
+    {{- if .Values.httproute.noindex }}
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Robots-Tag
+          value: "noindex, nofollow"
+    {{- end }}
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: {{ $fullName }}-api
+      namespace: {{ $serviceNamespace }}
+      port: {{ .Values.api.service.port }}
+      weight: 1
+  - matches:
+    - path:
+        type: Exact
+        value: /robots.txt
+    {{- if .Values.httproute.noindex }}
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Robots-Tag
+          value: "noindex, nofollow"
+    {{- end }}
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: {{ $fullName }}-api
+      namespace: {{ $serviceNamespace }}
+      port: {{ .Values.api.service.port }}
+      weight: 1
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    {{- if .Values.httproute.noindex }}
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Robots-Tag
+          value: "noindex, nofollow"
+    {{- end }}
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: {{ $fullName }}-frontend
+      namespace: {{ $serviceNamespace }}
+      port: {{ .Values.frontend.service.port }}
+      weight: 1
+---
+# webwhen API HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: webwhen-{{ $envPrefix }}api
+  namespace: clusterkit
+  labels:
+    {{- include "torale.labels" . | nindent 4 }}
+    app.kubernetes.io/component: routing
+  annotations:
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.httproute.gatewayName }}
+    namespace: clusterkit
+  hostnames:
+  - {{ .Values.domains.webwhen.api | quote }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    {{- if .Values.httproute.noindex }}
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Robots-Tag
+          value: "noindex, nofollow"
+    {{- end }}
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: {{ $fullName }}-api
+      namespace: {{ $serviceNamespace }}
+      port: {{ .Values.api.service.port }}
+      weight: 1
+{{- if and .Values.docs.enabled .Values.domains.webwhen.docs }}
+---
+# webwhen Docs HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: webwhen-{{ $envPrefix }}docs
+  namespace: clusterkit
+  labels:
+    {{- include "torale.labels" . | nindent 4 }}
+    app.kubernetes.io/component: routing
+  annotations:
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.httproute.gatewayName }}
+    namespace: clusterkit
+  hostnames:
+  - {{ .Values.domains.webwhen.docs | quote }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    {{- if .Values.httproute.noindex }}
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Robots-Tag
+          value: "noindex, nofollow"
+    {{- end }}
+    backendRefs:
+    - group: ""
+      kind: Service
+      name: {{ $fullName }}-docs
+      namespace: {{ $serviceNamespace }}
+      port: {{ .Values.docs.service.port }}
+      weight: 1
+{{- end }}
+{{- if and (not $isStagingRelease) .Values.domains.webwhen.www }}
+---
+# www.webwhen.ai → apex 301 redirect
+# Production-only (no www-staging hostname). Redirect-only HTTPRoute carries
+# no backendRefs; gateway-api spec allows RequestRedirect-only rules.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: webwhen-www-redirect
+  namespace: clusterkit
+  labels:
+    {{- include "torale.labels" . | nindent 4 }}
+    app.kubernetes.io/component: routing
+  annotations:
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.httproute.gatewayName }}
+    namespace: clusterkit
+  hostnames:
+  - {{ .Values.domains.webwhen.www | quote }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        hostname: {{ .Values.domains.webwhen.frontend | quote }}
+        statusCode: 301
+{{- end }}
+{{- end }}
 {{- end }}

--- a/helm/torale/values-webwhen-soak.yaml
+++ b/helm/torale/values-webwhen-soak.yaml
@@ -1,0 +1,49 @@
+# webwhen.ai soak-window overlay
+# ----------------------------------------------------------------------------
+# Layered on TOP of values-production.yaml (or values-staging.yaml) during
+# the soak window (T-2d → T-0). Renders the parallel webwhen.ai HTTPRoutes
+# alongside the existing torale.ai routes, with X-Robots-Tag: noindex on
+# every webwhen rule so the new domain doesn't compete in SERP before
+# cutover.
+#
+# Cert webwhen-ai-origin-cert (Cloudflare Origin CA wildcard) is already
+# attached to clusterkit-gateway via pre-shared-certs annotation; it covers
+# webwhen.ai apex + *.webwhen.ai. No per-route cert reference needed.
+#
+# Cutover-day mechanics (T-0):
+#   1. Drop this overlay from `helmfile -e <env> sync` invocation
+#      (or set httproute.noindex: false in values-production.yaml).
+#   2. Existing torale.ai routes stay live — flip torale.ai apex to a 301
+#      redirect → webwhen.ai in a follow-up commit (separate concern).
+#
+# IMPORTANT — DNS cleanup is NOT automatic:
+#   ExternalDNS in clusterkit runs `policy: upsert-only`, which means
+#   records are CREATED on HTTPRoute apply but NEVER DELETED on HTTPRoute
+#   remove. Any time you delete or rename a webwhen route (during the
+#   soak validation, at cutover, or during the torale.ai sunset window),
+#   orphan A/TXT records remain in Cloudflare. The runbook MUST include
+#   manual Cloudflare API cleanup for every hostname removed.
+#
+#   `dig` is unreliable for verifying cleanup on a Cloudflare-proxied
+#   zone — the CF nameservers return edge IPs for ANY name in a proxied
+#   zone whether a record exists or not. Verify via the Cloudflare API
+#   (`count=0` on the records endpoint), not dig.
+#
+# Apply:
+#   helm template torale helm/torale \
+#     -f helm/torale/values-production.yaml \
+#     -f helm/torale/values-webwhen-soak.yaml
+# ----------------------------------------------------------------------------
+
+httproute:
+  noindex: true
+
+domains:
+  webwhen:
+    # Production hostnames. Override in a staging-soak overlay (or invoke
+    # helmfile with values-staging.yaml + this file, then override frontend
+    # and api keys to the staging variants) for the staging soak.
+    frontend: webwhen.ai
+    www: www.webwhen.ai
+    api: api.webwhen.ai
+    docs: docs.webwhen.ai

--- a/helm/torale/values.yaml
+++ b/helm/torale/values.yaml
@@ -242,6 +242,35 @@ novu:
 httproute:
   enabled: true
   gatewayName: clusterkit-gateway
+  # Inject `X-Robots-Tag: noindex, nofollow` on every webwhen route.
+  # Used during the rebrand soak window (T-2d → T-0). Cutover-day diff =
+  # remove the values-webwhen-soak.yaml overlay (or set this to false).
+  # Has no effect when domains.webwhen is unset (no webwhen routes render).
+  noindex: false
+
+# webwhen.ai parallel routing (rebrand cutover).
+#
+# When unset (default), the chart renders only the torale.ai routes. To
+# enable webwhen routes, set domains.webwhen via an overlay
+# (values-webwhen-soak.yaml during soak; bake into values-production.yaml /
+# values-staging.yaml at cutover). The cert webwhen-ai-origin-cert covers
+# all hostnames listed below; it's pre-attached to clusterkit-gateway.
+#
+# Production overlay shape:
+#   domains:
+#     webwhen:
+#       frontend: webwhen.ai
+#       www: www.webwhen.ai
+#       api: api.webwhen.ai
+#       docs: docs.webwhen.ai
+#
+# Staging overlay shape (no www, no docs):
+#   domains:
+#     webwhen:
+#       frontend: staging.webwhen.ai
+#       api: api-staging.webwhen.ai
+#
+# domains.webwhen: {}  # leave commented; overlays set this
 
 # ConfigMap for non-sensitive configuration
 config:


### PR DESCRIPTION
Parallel webwhen.ai HTTPRoute set on the existing helm chart. Cutover-day diff is removing the soak overlay (or flipping `httproute.noindex: false`); no other route changes. Reviewable in isolation from PR #248 (frontend rebrand).

Milestone: [Rebrand: webwhen.ai (#9)](https://github.com/prassanna-ravishankar/torale/milestone/9). Sibling work: [clusterkit PR #1](https://github.com/prassanna-ravishankar/clusterkit/pull/1) (cert + DNS skeleton, landed), [clusterkit PR #3](https://github.com/prassanna-ravishankar/clusterkit/pull/3) (DNS sweep helpers + gotchas).

## What this PR does

Extends `helm/torale/templates/httproute.yaml` with a parallel webwhen.ai route set, gated on `domains.webwhen` being set. Until that key is provided (via `values-webwhen-soak.yaml` overlay), the chart deploys the existing torale.ai routes only — this PR is a no-op against any current `helmfile -e <env> sync` invocation.

When the soak overlay is layered on:

- **Production** (`-f values-production.yaml -f values-webwhen-soak.yaml`): renders 4 additional HTTPRoutes — `webwhen-main` (apex, 5 rules: 4 SEO endpoints to api + frontend catchall), `webwhen-api`, `webwhen-docs`, and `webwhen-www-redirect` (RequestRedirect 301 to apex). Existing 3 torale routes untouched.
- **Staging** (`-f values-staging.yaml -f values-webwhen-soak.yaml --set domains.webwhen.frontend=staging.webwhen.ai --set domains.webwhen.api=api-staging.webwhen.ai --set domains.webwhen.www=null --set domains.webwhen.docs=null`): renders 2 additional HTTPRoutes — `webwhen-staging-main` and `webwhen-staging-api`. No www-redirect (`!isStagingRelease` gate); no docs (no staging docs deployment). Existing 2 torale-staging routes untouched.

The existing `$envPrefix` ternary (`staging-` for staging release, empty for production) parameterizes route names automatically. The `$isStagingRelease` flag gates the production-only www-redirect.

## Soak window mechanics

Set `httproute.noindex: true` (the soak overlay does this) to inject `X-Robots-Tag: noindex, nofollow` on every webwhen non-redirect rule via `ResponseHeaderModifier` filter. Cloudflare-edge validated via clusterkit's gke-l7 ResponseHeaderModifier test (PR #3 sibling). The redirect-only `www-redirect` route correctly omits the noindex filter (redirects don't get indexed; the filter would be ignored on a `RequestRedirect`-only rule).

Cutover-day (T-0) diff is **a single overlay removal**:

```diff
- helmfile -e production sync \
-   -f helm/torale/values-production.yaml \
-   -f helm/torale/values-webwhen-soak.yaml
+ helmfile -e production sync \
+   -f helm/torale/values-production.yaml
```

Or equivalently, flip `httproute.noindex: false` in `values-production.yaml` if the soak overlay is being kept long-term. No HTTPRoute add/delete in either case — the noindex filter just disappears from rendered manifests.

**Important caveat (chart comments + soak overlay file both call this out)**:

> ExternalDNS in clusterkit runs `policy: upsert-only`. Records are CREATED on HTTPRoute apply but NEVER DELETED on HTTPRoute remove. Any HTTPRoute deleted or renamed leaves orphan A/TXT records in Cloudflare; cleanup is manual via Cloudflare API. `dig` is unreliable for verifying record absence on Cloudflare-proxied zones — verify via the CF API (`count=0`), not dig.

Captured in [clusterkit PR #3](https://github.com/prassanna-ravishankar/clusterkit/pull/3).

## Cert

All 6 webwhen hostnames share `webwhen-ai-origin-cert` (Cloudflare Origin CA wildcard, 15-yr expiry, covers `webwhen.ai` apex + `*.webwhen.ai`), pre-attached to `clusterkit-gateway` listener via the gateway's pre-shared-certs annotation. HTTPRoutes reference the gateway via `parentRefs`; no per-route cert config needed.

## Verification

`helm lint` clean against four overlay combinations:

- `helm lint helm/torale` (default values) — clean
- `helm lint helm/torale -f values-staging.yaml` — clean
- `helm lint helm/torale -f values-production.yaml` — clean
- `helm lint helm/torale -f values-production.yaml -f values-webwhen-soak.yaml` — clean

`helm template` rendered manifest assertions (production + soak):

| Route | Hostname | Rules | noindex filters | redirect filters |
|---|---|---|---|---|
| `torale-main` | torale.ai | 5 | 0 | 0 |
| `torale-api` | api.torale.ai | 1 | 0 | 0 |
| `torale-docs` | docs.torale.ai | 1 | 0 | 0 |
| `webwhen-main` | webwhen.ai | 5 | **5** | 0 |
| `webwhen-api` | api.webwhen.ai | 1 | **1** | 0 |
| `webwhen-docs` | docs.webwhen.ai | 1 | **1** | 0 |
| `webwhen-www-redirect` | www.webwhen.ai | 1 | 0 | **1** |

7/7 webwhen non-redirect rules carry noindex; redirect-only route has the redirect filter; torale routes untouched.

`helm template` rendered manifest assertions (staging + soak overrides):

| Route | Hostname | Rules | noindex filters | redirect filters |
|---|---|---|---|---|
| `torale-staging-main` | staging.torale.ai | 5 | 0 | 0 |
| `torale-staging-api` | api-staging.torale.ai | 1 | 0 | 0 |
| `webwhen-staging-main` | staging.webwhen.ai | 5 | 5 | 0 |
| `webwhen-staging-api` | api-staging.webwhen.ai | 1 | 1 | 0 |

No www-redirect (correct, `!isStagingRelease`); no staging docs (correct, no staging docs deployment).

Without the soak overlay (default values, default production, default staging): zero webwhen routes render. The chart change is a no-op against any current invocation.

## Test plan

- [ ] Code review of helm template (logic + comment block)
- [ ] Reviewer renders chart locally with each of the 4 overlay combos and inspects diff
- [ ] At T-2d: apply `helmfile -e production sync -f values-production.yaml -f values-webwhen-soak.yaml`, confirm 4 webwhen routes appear in the cluster, confirm `X-Robots-Tag: noindex, nofollow` on `curl -I https://webwhen.ai/`
- [ ] At T-2d (staging): apply staging soak overlay with overrides, validate end-to-end (frontend reachable on staging.webwhen.ai, api on api-staging.webwhen.ai, both with noindex header)
- [ ] At T-0: drop the overlay, confirm noindex header disappears, no other diff. Old torale.ai routes stay live; sunset is a separate concern.
- [ ] Post-cutover: run clusterkit's dnsctl helper to verify no orphan A/TXT records for any deleted/renamed hostname (CF API `count=0`, not dig).

## Out of scope (deliberately separate concerns)

- `torale.ai` apex 301-to-`webwhen.ai` redirect — follow-up commit, post-cutover-day, when we're ready to start the sunset.
- Backend module rename (`backend/src/torale/` → `backend/src/webwhen/`), helm chart rename, repo rename — all deferred per CLAUDE.md.
- Any clusterkit-side terraform changes — sibling PR (now landed for cert; future work for sweep helpers in clusterkit PR #3).

## Ergonomics note

The soak overlay's `domains.webwhen` defaults to production hostnames; staging soak requires `--set` overrides at deploy time. If operator ergonomics matter more, a sibling `values-webwhen-soak-staging.yaml` is a 10-line follow-up. Held off in this PR to keep the diff to one overlay file; happy to add it if review prefers.