### PR TITLE
T-0 cutover: webwhen.ai indexable + 301 redirects on torale.ai

### DIFF
--- a/helm/torale/templates/httproute.yaml
+++ b/helm/torale/templates/httproute.yaml
@@ -3,6 +3,13 @@
 {{- $isStagingRelease := eq .Release.Namespace "torale-staging" -}}
 {{- $serviceNamespace := ternary "torale-staging" "torale" $isStagingRelease -}}
 {{- $envPrefix := ternary "staging-" "" $isStagingRelease -}}
+{{/*
+  $isCutover: when true, the torale.ai HTTPRoutes serve 301 RequestRedirect
+  filters pointing to the webwhen.ai equivalents (path preserved). Set when
+  .Values.httproute.cutover is true. This is the T-0 cutover state.
+  Pre-cutover (during the soak window), the torale routes serve normally.
+*/}}
+{{- $isCutover := eq (.Values.httproute.cutover | toString) "true" -}}
 ---
 # Frontend HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1
@@ -25,6 +32,19 @@ spec:
   hostnames:
   - {{ .Values.domains.frontend | quote }}
   rules:
+  {{- if $isCutover }}
+  # T-0 cutover: 301 redirect torale.ai/* → webwhen.ai/* (path preserved)
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        hostname: {{ .Values.domains.webwhen.frontend | quote }}
+        statusCode: 301
+  {{- else }}
   # SEO endpoints served by backend API (must be before frontend catchall)
   - matches:
     - path:
@@ -82,6 +102,7 @@ spec:
       namespace: {{ $serviceNamespace }}  # Cross-namespace reference to service
       port: {{ .Values.frontend.service.port }}
       weight: 1
+  {{- end }}
 ---
 # API HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1
@@ -103,6 +124,19 @@ spec:
   hostnames:
   - {{ .Values.domains.api | quote }}
   rules:
+  {{- if $isCutover }}
+  # T-0 cutover: 301 redirect api.torale.ai/* → api.webwhen.ai/* (path preserved)
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        hostname: {{ .Values.domains.webwhen.api | quote }}
+        statusCode: 301
+  {{- else }}
   - matches:
     - path:
         type: PathPrefix
@@ -114,6 +148,7 @@ spec:
       namespace: {{ $serviceNamespace }}
       port: {{ .Values.api.service.port }}
       weight: 1
+  {{- end }}
 {{- if .Values.docs.enabled }}
 ---
 # Docs HTTPRoute
@@ -136,6 +171,19 @@ spec:
   hostnames:
   - {{ .Values.domains.docs | quote }}
   rules:
+  {{- if $isCutover }}
+  # T-0 cutover: 301 redirect docs.torale.ai/* → docs.webwhen.ai/* (path preserved)
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        hostname: {{ .Values.domains.webwhen.docs | quote }}
+        statusCode: 301
+  {{- else }}
   - matches:
     - path:
         type: PathPrefix
@@ -147,6 +195,7 @@ spec:
       namespace: {{ $serviceNamespace }}
       port: {{ .Values.docs.service.port }}
       weight: 1
+  {{- end }}
 {{- end }}
 
 # ============================================================================

--- a/helm/torale/values-production.yaml
+++ b/helm/torale/values-production.yaml
@@ -3,6 +3,20 @@
 domains:
   frontend: torale.ai
   api: api.torale.ai
+  # webwhen.ai cutover (T-0, 2026-05-03):
+  # webwhen routes now ship with the production chart (no soak overlay).
+  # noindex flag is OFF (httproute.noindex: false) so webwhen.ai is
+  # crawlable. The torale routes are flipped to 301 RequestRedirect via
+  # the chart template's $isCutover branch.
+  webwhen:
+    frontend: webwhen.ai
+    www: www.webwhen.ai
+    api: api.webwhen.ai
+    docs: docs.webwhen.ai
+
+httproute:
+  noindex: false  # cutover-day: webwhen routes are indexable
+  cutover: true   # T-0: torale.ai routes serve 301 RequestRedirect to webwhen.ai
 
 # Clerk authentication
 # Rotated 2026-05-03 from torale.ai-primary key to webwhen.ai-primary key per


### PR DESCRIPTION
## What

T-0 cutover. Single helmfile sync delivers two changes simultaneously:

1. webwhen.ai routes ship without the soak overlay (`httproute.noindex: false` in production values) — webwhen.ai becomes crawlable
2. torale.ai HTTPRoutes flip to 301 RequestRedirect filters pointing at webwhen.ai equivalents (`httproute.cutover: true`)

Single sync = single propagation window = no SERP race where both domains are indexable simultaneously, and no window where torale.ai 301s to a noindex'd webwhen.

## Diff

`helm/torale/values-production.yaml`:
- Add `domains.webwhen` block (frontend/www/api/docs)
- Add `httproute.noindex: false` (default would be unset; explicit false for clarity)
- Add `httproute.cutover: true` (T-0 flag)

`helm/torale/templates/httproute.yaml`:
- Add `$isCutover` flag at top
- Wrap each torale-* route's rules in `{{- if $isCutover }}` branch:
  - cutover branch: single PathPrefix match with RequestRedirect filter (scheme: https, hostname: webwhen equivalent, statusCode: 301, path preserved)
  - else branch: original backend-routing rules

## Verification

`helm lint helm/torale -f helm/torale/values-production.yaml` clean.

Rendered manifest assertions (production):

| Route | Hostnames | Behavior |
|---|---|---|
| torale-main | torale.ai | 301 → webwhen.ai/$path |
| torale-api | api.torale.ai | 301 → api.webwhen.ai/$path |
| torale-docs | docs.torale.ai | 301 → docs.webwhen.ai/$path |
| webwhen-main | webwhen.ai | frontend catchall + 4 SEO routes (no noindex) |
| webwhen-api | api.webwhen.ai | api catchall (no noindex) |
| webwhen-docs | docs.webwhen.ai | docs catchall (no noindex) |
| webwhen-www-redirect | www.webwhen.ai | 301 → webwhen.ai |

7 HTTPRoutes total. Zero `X-Robots-Tag: noindex` ResponseHeaderModifier filters in rendered manifests.

## Cutover-day rollback

If anything breaks, revert this PR. helmfile sync re-applies. torale serves normally; webwhen routes return to soak overlay state.

Closes #257.
Milestone: [Rebrand: webwhen.ai (#9)](https://github.com/prassanna-ravishankar/torale/milestone/9)