### PR TITLE
fix(helm): point frontend + backend URLs at webwhen hostnames

### DIFF
--- a/helm/torale/templates/configmap.yaml
+++ b/helm/torale/templates/configmap.yaml
@@ -18,8 +18,12 @@ data:
   AGENT_URL: {{ printf "http://%s-agent-free" (include "torale.fullname" .) | quote }}
 
   # API configuration
-  API_URL: {{ printf "https://%s" .Values.domains.api | quote }}
-  FRONTEND_URL: {{ printf "https://%s" .Values.domains.frontend | quote }}
+  # Post-cutover: backend's self-URL + frontend-URL must point at the new
+  # hostnames (used for email links, OAuth callbacks, etc.). The legacy
+  # domains.{api,frontend} values are intentionally pinned to torale.ai as the
+  # 301-redirect source in httproute.yaml; do not read them from here.
+  API_URL: {{ printf "https://%s" .Values.domains.webwhen.api | quote }}
+  FRONTEND_URL: {{ printf "https://%s" .Values.domains.webwhen.frontend | quote }}
 
   # Platform capacity
   MAX_USERS: {{ .Values.capacity.maxUsers | quote }}

--- a/helm/torale/templates/configmap.yaml
+++ b/helm/torale/templates/configmap.yaml
@@ -17,13 +17,14 @@ data:
   # Keep AGENT_URL for backward compatibility
   AGENT_URL: {{ printf "http://%s-agent-free" (include "torale.fullname" .) | quote }}
 
-  # API configuration
-  # Post-cutover: backend's self-URL + frontend-URL must point at the new
-  # hostnames (used for email links, OAuth callbacks, etc.). The legacy
-  # domains.{api,frontend} values are intentionally pinned to torale.ai as the
-  # 301-redirect source in httproute.yaml; do not read them from here.
-  API_URL: {{ printf "https://%s" .Values.domains.webwhen.api | quote }}
-  FRONTEND_URL: {{ printf "https://%s" .Values.domains.webwhen.frontend | quote }}
+  # API + frontend self-URLs (used for email links, OAuth callbacks, etc.).
+  # Post-cutover (production), the live hosts are .Values.domains.webwhen.*;
+  # the legacy .Values.domains.{api,frontend} are pinned to torale.ai as the
+  # 301-redirect source in httproute.yaml. On surfaces with no parallel-route
+  # setup (staging, dev), domains.webwhen is absent and the legacy keys ARE
+  # the live hosts.
+  API_URL: {{ printf "https://%s" (default .Values.domains.api (dig "webwhen" "api" "" .Values.domains)) | quote }}
+  FRONTEND_URL: {{ printf "https://%s" (default .Values.domains.frontend (dig "webwhen" "frontend" "" .Values.domains)) | quote }}
 
   # Platform capacity
   MAX_USERS: {{ .Values.capacity.maxUsers | quote }}

--- a/helm/torale/templates/frontend-config.yaml
+++ b/helm/torale/templates/frontend-config.yaml
@@ -9,7 +9,7 @@ data:
   config.js: |
     // Runtime configuration injected by Kubernetes
     window.CONFIG = {
-      apiUrl: 'https://{{ .Values.domains.api }}',
+      apiUrl: 'https://{{ .Values.domains.webwhen.api }}',
       clerkPublishableKey: '{{ .Values.clerk.publishableKey }}',
       {{- if .Values.posthog.enabled }}
       posthogApiKey: '{{ .Values.posthog.apiKey }}',

--- a/helm/torale/templates/frontend-config.yaml
+++ b/helm/torale/templates/frontend-config.yaml
@@ -1,4 +1,12 @@
 {{- if .Values.frontend.enabled -}}
+{{- /*
+Live API hostname. Post-cutover (production), the live host is
+.Values.domains.webwhen.api; the legacy .Values.domains.api is pinned to
+torale.ai as the 301-redirect source (see httproute.yaml). On surfaces with
+no parallel-route setup (staging, dev, default chart values), domains.webwhen
+is absent and the legacy key IS the live host. Fall back accordingly.
+*/ -}}
+{{- $apiHost := default .Values.domains.api (dig "webwhen" "api" "" .Values.domains) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,7 +17,7 @@ data:
   config.js: |
     // Runtime configuration injected by Kubernetes
     window.CONFIG = {
-      apiUrl: 'https://{{ .Values.domains.webwhen.api }}',
+      apiUrl: 'https://{{ $apiHost }}',
       clerkPublishableKey: '{{ .Values.clerk.publishableKey }}',
       {{- if .Values.posthog.enabled }}
       posthogApiKey: '{{ .Values.posthog.apiKey }}',


### PR DESCRIPTION
Fixes #268.

## Summary

Post-cutover dashboard at `webwhen.ai` was showing "Couldn't load your watches". Root cause: the runtime-injected `/config.js` served `apiUrl: 'https://api.torale.ai'` — the legacy hostname, which now serves a 301 redirect. Credentialed cross-origin redirects don't carry the Clerk session cookie (now scoped to `webwhen.ai`), so every authenticated API call failed.

## Changes

- `frontend-config.yaml` — `apiUrl` reads `domains.webwhen.api` (was `domains.api`)
- `configmap.yaml` — backend `API_URL` and `FRONTEND_URL` env vars also flipped to the `domains.webwhen.*` keys (used by email links, OAuth callbacks)

`domains.api` / `domains.frontend` stay pinned to the torale.ai hostnames in `values-production.yaml` because `httproute.yaml` reads them as the 301-redirect *source*. Inline comment added so this isn't re-broken.

## Verified

```
$ helm template torale helm/torale -f helm/torale/values-production.yaml | grep -E "API_URL:|FRONTEND_URL:|apiUrl:"
API_URL: "https://api.webwhen.ai"
FRONTEND_URL: "https://webwhen.ai"
apiUrl: 'https://api.webwhen.ai',
```

## Test plan

- [ ] CI green
- [ ] Merge → production deploy → confirm `curl https://webwhen.ai/config.js` shows `apiUrl: 'https://api.webwhen.ai'`
- [ ] Confirm dashboard loads watches end-to-end for an authenticated user