### PR TITLE
fix(docs): use dark variant of mark in dark theme nav

### DIFF
--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -75,7 +75,11 @@ export default withMermaid(
   },
 
   themeConfig: {
-    logo: '/logo.svg',
+    // Dark-mode variant: the static mark hardcodes #0B0B0C ink, so a separate
+    // light-on-dark asset is needed for the dark theme nav (same pattern as
+    // the frontend Footer's webwhen-mark-dark.svg). Replace with a single
+    // currentColor mark when the design system ships one.
+    logo: { light: '/logo.svg', dark: '/logo-dark.svg' },
 
     nav: [
       { text: 'Getting Started', link: '/getting-started/', activeMatch: '/getting-started/' },

--- a/docs-site/public/logo-dark.svg
+++ b/docs-site/public/logo-dark.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <g stroke="#FAFAF7" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M8.5 5 L23.5 5"></path>
+    <path d="M8.5 27 L23.5 27"></path>
+    <path d="M9.5 5.5 C 9.5 11, 16 13.5, 16 16 C 16 18.5, 9.5 21, 9.5 26.5"></path>
+    <path d="M22.5 5.5 C 22.5 11, 16 13.5, 16 16 C 16 18.5, 22.5 21, 22.5 26.5"></path>
+  </g>
+  <path d="M11.6 25.4 C 12.8 23, 14.3 22, 16 22 C 17.7 22, 19.2 23, 20.4 25.4 Z" fill="#FAFAF7" opacity="0.62"></path>
+  <circle cx="16" cy="19" r="1.35" fill="#C9582A"></circle>
+</svg>


### PR DESCRIPTION
## Summary

The docs-site `/logo.svg` hardcodes `#0B0B0C` ink, so the mark is invisible in the dark theme nav (and the wordmark next to it sits next to a phantom).

Same pattern as the frontend `Footer` (already shipping with `webwhen-mark-dark.svg` for dark surfaces). Brought the same asset into `docs-site/public/logo-dark.svg` and switched the nav config to VitePress's `{ light, dark }` form.

Hero image (`index.md` frontmatter) **not** touched — separate concern.

## Changes

- `docs-site/public/logo-dark.svg` — added (light-on-dark variant of the mark, copied from `frontend/public/brand/webwhen-mark-dark.svg`)
- `docs-site/.vitepress/config.ts` — `themeConfig.logo` now `{ light: '/logo.svg', dark: '/logo-dark.svg' }` with a comment noting this is a stopgap until the design system ships a `currentColor` mark

## Test plan

- [x] `npm run docs:build` ✓ (build complete, sitemap + nginx-redirects generated)
- [ ] Post-deploy: visit `https://docs.webwhen.ai`, toggle dark mode, confirm the nav mark is visible