### PR TITLE
feat(frontend): animated webwhen mark for triggered watches + watch creation

### DIFF
--- a/frontend/public/brand/webwhen-mark-animated.svg
+++ b/frontend/public/brand/webwhen-mark-animated.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <g stroke="#0B0B0C" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M8.5 5 L23.5 5"></path>
+    <path d="M8.5 27 L23.5 27"></path>
+    <path d="M9.5 5.5 C 9.5 11, 16 13.5, 16 16 C 16 18.5, 9.5 21, 9.5 26.5"></path>
+    <path d="M22.5 5.5 C 22.5 11, 16 13.5, 16 16 C 16 18.5, 22.5 21, 22.5 26.5"></path>
+  </g>
+
+  <path class="ww-mark__top-sand" d="M10.2 5.7 C 10.4 9.5, 13 12, 16 12.5 C 19 12, 21.6 9.5, 21.8 5.7 Z" fill="#0B0B0C" opacity="0.62"></path>
+
+  <line class="ww-mark__stream" x1="16" y1="13" x2="16" y2="22" stroke="#0B0B0C" stroke-width="1" stroke-linecap="round" opacity="0.55"></line>
+
+  <path class="ww-mark__pile" d="M11.6 25.4 C 12.8 23, 14.3 22, 16 22 C 17.7 22, 19.2 23, 20.4 25.4 Z" fill="#0B0B0C" opacity="0.62"></path>
+
+  <circle class="ww-mark__glow" cx="16" cy="19" r="1.35" fill="#C9582A" opacity="0"></circle>
+  <circle class="ww-mark__ember" cx="16" cy="19" r="1.35" fill="#C9582A"></circle>
+</svg>

--- a/frontend/src/components/TaskCreationDialog.tsx
+++ b/frontend/src/components/TaskCreationDialog.tsx
@@ -8,6 +8,9 @@ import { cn, getErrorMessage } from "@/lib/utils";
 import styles from "./composer/Composer.module.css";
 import modalStyles from "./ui/modal/Modal.module.css";
 import landing from "./landing/Landing.module.css";
+import { WebwhenMark } from "./WebwhenMark";
+
+const STARTING_ANIM_MS = 2400;
 
 interface TaskCreationDialogProps {
   open: boolean;
@@ -49,6 +52,7 @@ export const TaskCreationDialog: React.FC<TaskCreationDialogProps> = ({
     setError("");
     setSubmitting(true);
 
+    const animStart = performance.now();
     try {
       // Backend/agent derives the name from the condition; no explicit name field.
       const newTask = await api.createTask({
@@ -58,6 +62,14 @@ export const TaskCreationDialog: React.FC<TaskCreationDialogProps> = ({
         run_immediately: true,
         attached_connector_slugs: attachedConnectors,
       });
+
+      // Let the starting animation complete before the modal closes.
+      // The agent is "patient and watchful" — match that with the brand mark.
+      const elapsed = performance.now() - animStart;
+      const remaining = Math.max(0, STARTING_ANIM_MS - elapsed);
+      if (remaining > 0) {
+        await new Promise((r) => setTimeout(r, remaining));
+      }
 
       onTaskCreated(newTask);
       onOpenChange(false);
@@ -134,7 +146,14 @@ export const TaskCreationDialog: React.FC<TaskCreationDialogProps> = ({
               disabled={!canSubmit}
               className={cn(landing.btn, landing.btnPrimary)}
             >
-              {submitting ? "Creating…" : "Watch →"}
+              {submitting ? (
+                <span className={styles.submittingMark}>
+                  <WebwhenMark animated="starting" oneShot size={18} />
+                  watching
+                </span>
+              ) : (
+                "Watch →"
+              )}
             </button>
           </div>
         </div>

--- a/frontend/src/components/TaskDetail.tsx
+++ b/frontend/src/components/TaskDetail.tsx
@@ -11,6 +11,7 @@ import { DeleteMonitorDialog } from '@/components/torale'
 import { ConnectorDegradationBanner } from '@/components/connectors/ConnectorDegradationBanner'
 import { MomentBlock } from '@/components/watch/MomentBlock'
 import { RunTimeline } from '@/components/watch/RunTimeline'
+import { WebwhenMark } from '@/components/WebwhenMark'
 import landingStyles from '@/components/landing/Landing.module.css'
 import styles from '@/components/watch/Watch.module.css'
 import { cn, formatTimeAgo, formatTimeUntil } from '@/lib/utils'
@@ -265,6 +266,9 @@ export const TaskDetail: React.FC<TaskDetailProps> = ({
       <header className={styles.detailHead}>
         <div className={styles.left}>
           <div className={styles.pillRow}>
+            {hasFreshTrigger && (
+              <WebwhenMark animated="triggered" size={20} title="triggered" />
+            )}
             <span className={cn(styles.pill, pillClass)}>{pillLabel}</span>
           </div>
           <h1 className={styles.question}>{task.condition_description}</h1>

--- a/frontend/src/components/WebwhenMark.tsx
+++ b/frontend/src/components/WebwhenMark.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+type AnimatedState = "none" | "starting" | "triggered";
+
+interface WebwhenMarkProps {
+  animated?: AnimatedState;
+  /**
+   * When true and `animated="starting"`, runs the 2.4s cycle once instead of
+   * looping. Use for one-off moments like watch creation.
+   */
+  oneShot?: boolean;
+  /** Pixel size for both width + height. Defaults to 28 (matches Logo). */
+  size?: number;
+  className?: string;
+  title?: string;
+}
+
+/**
+ * Inline SVG webwhen mark with optional motion states.
+ * Animation contract is defined in design/webwhen/motion.css and imported
+ * via frontend/src/index.css; class names here must stay in sync.
+ */
+export const WebwhenMark: React.FC<WebwhenMarkProps> = ({
+  animated = "none",
+  oneShot = false,
+  size = 28,
+  className,
+  title,
+}) => {
+  const stateClass =
+    animated === "starting"
+      ? cn("ww-mark--starting", oneShot && "ww-mark--once")
+      : animated === "triggered"
+      ? "ww-mark--triggered"
+      : undefined;
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 32 32"
+      width={size}
+      height={size}
+      fill="none"
+      role={title ? "img" : "presentation"}
+      aria-label={title}
+      aria-hidden={title ? undefined : true}
+      className={cn(stateClass, className)}
+    >
+      <g
+        stroke="#0B0B0C"
+        strokeWidth={1.75}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      >
+        <path d="M8.5 5 L23.5 5" />
+        <path d="M8.5 27 L23.5 27" />
+        <path d="M9.5 5.5 C 9.5 11, 16 13.5, 16 16 C 16 18.5, 9.5 21, 9.5 26.5" />
+        <path d="M22.5 5.5 C 22.5 11, 16 13.5, 16 16 C 16 18.5, 22.5 21, 22.5 26.5" />
+      </g>
+
+      <path
+        className="ww-mark__top-sand"
+        d="M10.2 5.7 C 10.4 9.5, 13 12, 16 12.5 C 19 12, 21.6 9.5, 21.8 5.7 Z"
+        fill="#0B0B0C"
+        opacity={0.62}
+      />
+
+      <line
+        className="ww-mark__stream"
+        x1={16}
+        y1={13}
+        x2={16}
+        y2={22}
+        stroke="#0B0B0C"
+        strokeWidth={1}
+        strokeLinecap="round"
+        opacity={0.55}
+      />
+
+      <path
+        className="ww-mark__pile"
+        d="M11.6 25.4 C 12.8 23, 14.3 22, 16 22 C 17.7 22, 19.2 23, 20.4 25.4 Z"
+        fill="#0B0B0C"
+        opacity={0.62}
+      />
+
+      <circle
+        className="ww-mark__glow"
+        cx={16}
+        cy={19}
+        r={1.35}
+        fill="#C9582A"
+        opacity={0}
+      />
+      <circle
+        className="ww-mark__ember"
+        cx={16}
+        cy={19}
+        r={1.35}
+        fill="#C9582A"
+      />
+    </svg>
+  );
+};
+
+export default WebwhenMark;

--- a/frontend/src/components/WebwhenMark.tsx
+++ b/frontend/src/components/WebwhenMark.tsx
@@ -45,10 +45,10 @@ export const WebwhenMark: React.FC<WebwhenMarkProps> = ({
       role={title ? "img" : "presentation"}
       aria-label={title}
       aria-hidden={title ? undefined : true}
-      className={cn(stateClass, className)}
+      className={cn("ww-mark", stateClass, className)}
     >
       <g
-        stroke="#0B0B0C"
+        stroke="currentColor"
         strokeWidth={1.75}
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -63,7 +63,7 @@ export const WebwhenMark: React.FC<WebwhenMarkProps> = ({
       <path
         className="ww-mark__top-sand"
         d="M10.2 5.7 C 10.4 9.5, 13 12, 16 12.5 C 19 12, 21.6 9.5, 21.8 5.7 Z"
-        fill="#0B0B0C"
+        fill="currentColor"
         opacity={0.62}
       />
 
@@ -73,7 +73,7 @@ export const WebwhenMark: React.FC<WebwhenMarkProps> = ({
         y1={13}
         x2={16}
         y2={22}
-        stroke="#0B0B0C"
+        stroke="currentColor"
         strokeWidth={1}
         strokeLinecap="round"
         opacity={0.55}
@@ -82,7 +82,7 @@ export const WebwhenMark: React.FC<WebwhenMarkProps> = ({
       <path
         className="ww-mark__pile"
         d="M11.6 25.4 C 12.8 23, 14.3 22, 16 22 C 17.7 22, 19.2 23, 20.4 25.4 Z"
-        fill="#0B0B0C"
+        fill="currentColor"
         opacity={0.62}
       />
 

--- a/frontend/src/components/composer/Composer.module.css
+++ b/frontend/src/components/composer/Composer.module.css
@@ -148,3 +148,10 @@
   font-size: 12px;
   color: #944;
 }
+
+/* === Submitting state on the primary button ============================ */
+.submittingMark {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -366,6 +366,10 @@
    .ww-mark__ember, .ww-mark__glow.
    ========================================================================== */
 
+.ww-mark {
+  color: var(--ww-ink-0);
+}
+
 .ww-mark--starting .ww-mark__top-sand {
   transform-origin: 16px 5px;
   animation: ww-start-top 2400ms cubic-bezier(0.4, 0, 0.6, 1) infinite;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -354,3 +354,76 @@
     background-size: 28px 28px;
   }
 }
+
+/* ============================================================================
+   webwhen — animated mark
+   Copied from design/webwhen/motion.css (design/ is reference, not built).
+   Three states applied as classes on the inline SVG root:
+     .ww-mark--starting           one-shot 2.4s cycle (loops by default)
+     .ww-mark--starting.ww-mark--once    runs the cycle exactly once
+     .ww-mark--triggered          looping 1.6s pulse + halo
+   Required SVG hooks: .ww-mark__top-sand, .ww-mark__pile, .ww-mark__stream,
+   .ww-mark__ember, .ww-mark__glow.
+   ========================================================================== */
+
+.ww-mark--starting .ww-mark__top-sand {
+  transform-origin: 16px 5px;
+  animation: ww-start-top 2400ms cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+.ww-mark--starting .ww-mark__pile {
+  transform-origin: 16px 27px;
+  animation: ww-start-pile 2400ms cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+.ww-mark--starting .ww-mark__stream {
+  animation: ww-start-stream 2400ms cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+.ww-mark--starting .ww-mark__ember {
+  animation: ww-start-ember 2400ms cubic-bezier(0.55, 0, 0.55, 1) infinite;
+}
+
+.ww-mark--starting.ww-mark--once .ww-mark__top-sand,
+.ww-mark--starting.ww-mark--once .ww-mark__pile,
+.ww-mark--starting.ww-mark--once .ww-mark__stream,
+.ww-mark--starting.ww-mark--once .ww-mark__ember {
+  animation-iteration-count: 1;
+  animation-fill-mode: forwards;
+}
+
+@keyframes ww-start-top  { 0% { transform: scaleY(1); }   95%, 100% { transform: scaleY(0.05); } }
+@keyframes ww-start-pile { 0% { transform: scaleY(0.1); } 95%, 100% { transform: scaleY(1); } }
+@keyframes ww-start-stream {
+  0%        { opacity: 0; transform: scaleY(0); }
+  8%, 92%   { opacity: 0.55; transform: scaleY(1); }
+  100%      { opacity: 0; transform: scaleY(0); }
+}
+@keyframes ww-start-ember {
+  0%   { transform: translate(0, -6px); opacity: 0; }
+  10%  { opacity: 1; }
+  50%  { transform: translate(0, 0px); opacity: 1; }
+  62%  { transform: translate(0, 4px); opacity: 0; }
+  100% { transform: translate(0, 4px); opacity: 0; }
+}
+
+.ww-mark--triggered .ww-mark__ember {
+  transform-origin: 16px 19px;
+  animation: ww-trig-pulse 1600ms ease-in-out infinite;
+}
+.ww-mark--triggered .ww-mark__glow {
+  transform-origin: 16px 19px;
+  animation: ww-trig-glow 1600ms ease-in-out infinite;
+}
+
+@keyframes ww-trig-pulse {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.6); }
+}
+@keyframes ww-trig-glow {
+  0%, 100% { opacity: 0; transform: scale(1); }
+  50%      { opacity: 0.35; transform: scale(2.4); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ww-mark--starting *,
+  .ww-mark--triggered * { animation: none !important; }
+}
+


### PR DESCRIPTION
## Summary

Wires up the animated states the design system already defined in `design/webwhen/motion.css` but that had zero usages. Two natural homes:

- **Triggered watches** — looping 1.6s ember pulse + halo on the `TaskDetail` header, gated on `hasFreshTrigger`. Signals "this is the moment that matters".
- **Watch creation** — one-shot 2.4s starting cycle replaces the bare "Creating…" spinner on `TaskCreationDialog` submit. Submit handler waits for the animation to play out before closing the modal — matches the brand voice "patient and watchful, the agent settles into the question".

WatchRow swap deliberately skipped: existing 8px ember dot already pulses on triggered, and a 14px hourglass crowded the row.

## Changes

- `frontend/public/brand/webwhen-mark-animated.svg` — new multi-element source SVG with the motion.css structural hooks (`top-sand`, `pile`, `stream`, `ember`, `glow`). Static `webwhen-mark.svg` left untouched.
- `frontend/src/components/WebwhenMark.tsx` — `<WebwhenMark animated="starting|triggered|none" oneShot size title />`. Inline SVG with the class hooks; renders `ww-mark--starting` (+ `ww-mark--once` when `oneShot`) or `ww-mark--triggered` on the root. Uses `currentColor` for strokes/fills so it composes on dark surfaces; ember is hardcoded `#C9582A` (brand color, not theme-dependent).
- `frontend/src/index.css` — motion.css copied verbatim from `design/webwhen/motion.css` (design/ is reference, not built) plus a small app-side `.ww-mark--once` modifier (`animation-iteration-count: 1; animation-fill-mode: forwards`) so the one-shot ends in a settled state instead of snapping back. `prefers-reduced-motion` block carried over.
- `frontend/src/components/TaskDetail.tsx` — renders `<WebwhenMark animated="triggered" size={20} title="triggered">` next to the existing pill when `hasFreshTrigger`.
- `frontend/src/components/TaskCreationDialog.tsx` — submit button content swaps to `<WebwhenMark animated="starting" oneShot size={18}/> watching` while submitting; submit handler measures elapsed and only waits for the *remaining* delta of the 2.4s animation (fast API → ~zero extra wait; slow API → no extra wait).
- `frontend/src/components/composer/Composer.module.css` — `.submittingMark` flex helper.

## Don't-touch list (preserved per scope)

- `Logo.tsx`, `Sidebar.tsx`, `Nav.tsx`, `Footer.tsx` — kept on the static `<img src="/brand/webwhen-mark.svg">` per the brief.
- Marketing Landing hero — stretch goal, deferred.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Lint clean
- [ ] Visual smoke on Chrome (dev): create a watch, see one-shot starting cycle on submit; open a watch in `triggered` status, see pulsing ember + halo
- [ ] Visual smoke on Safari (different SVG animation rasterization)
- [ ] Toggle `prefers-reduced-motion` at OS level, confirm both states render static (no animation)