### PR TITLE
fix(docs): hero illustration uses dark variant in dark mode

### DIFF
--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -7,7 +7,8 @@ hero:
   text: Build with the agent that waits.
   tagline: Tell webwhen what to watch for. It will sit with the question and tell you when the answer arrives.
   image:
-    src: /logo.svg
+    light: /logo.svg
+    dark: /logo-dark.svg
     alt: webwhen
   actions:
     - theme: brand


### PR DESCRIPTION
Closes #273.

## Summary

Sibling fix to #271. The home-page hero illustration in `index.md` was set as `image: { src: /logo.svg }`, hardcoded `#0B0B0C` ink, so the entire hourglass illustration was near-invisible in dark mode (only the ember + faint pile shape showed).

VitePress 1.5+ supports `image: { light, dark, alt }` on the home hero. Reusing the `/logo-dark.svg` asset that #271 added for the nav.

## Changes

- `docs-site/index.md` — hero `image` shape from `{ src, alt }` to `{ light, dark, alt }`. Same `/logo.svg` for light, `/logo-dark.svg` for dark.

## Verified

`npm run docs:build` clean. Inspected prerendered `dist/index.html`: both `<img class="VPImage dark image-src" src="/logo-dark.svg">` and `<img class="VPImage light image-src" src="/logo.svg">` are present in the hero, VitePress's CSS toggles visibility per theme.

## Test plan

- [x] `npm run docs:build` clean
- [x] Prerendered HTML contains both variants
- [ ] Post-deploy: visit `https://docs.webwhen.ai`, toggle dark mode, confirm hero illustration is visible