### PR TITLE
fix(seo): bake changelog JSON-LD into prerendered /changelog

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -79,6 +79,14 @@ jobs:
       - name: Configure Docker for GCR
         run: gcloud auth configure-docker gcr.io
 
+      # Frontend prerender bakes article-level JSON-LD into dist/changelog.html
+      # using backend/static/changelog.json. The frontend image build context is
+      # `frontend/` and cannot reach `../backend/`, so stage the fixture inside
+      # the context first. See frontend/scripts/sync-changelog-fixture.mjs.
+      - name: Stage changelog fixture for frontend prerender
+        if: matrix.component == 'frontend'
+        run: cp backend/static/changelog.json frontend/.changelog-fixture.json
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -53,6 +53,12 @@ jobs:
       - name: Configure Docker for GCR
         run: gcloud auth configure-docker gcr.io
 
+      # See production.yml for context: stages backend/static/changelog.json
+      # inside the frontend build context so prerender can bake JSON-LD.
+      - name: Stage changelog fixture for frontend prerender
+        if: matrix.component == 'frontend'
+        run: cp backend/static/changelog.json frontend/.changelog-fixture.json
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -66,6 +66,10 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: true
           provenance: false
+          # Stage origin baked into prerendered JSON-LD / RSS / etc. for the
+          # frontend image only. Other components ignore the arg.
+          build-args: |
+            PRERENDER_ORIGIN=https://staging.torale.ai
           tags: |
             gcr.io/${{ env.GCP_PROJECT_ID }}/torale-${{ matrix.component }}:${{ env.IMAGE_TAG }}
             gcr.io/${{ env.GCP_PROJECT_ID }}/torale-${{ matrix.component }}:staging

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -10,6 +10,10 @@ node_modules
 /build
 /dist
 
+# Synced from backend/static/changelog.json by scripts/sync-changelog-fixture.mjs
+# at build time. See scripts/prerender.mjs for the why.
+/.changelog-fixture.json
+
 # Misc
 .DS_Store
 .env.local

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,6 +6,13 @@ FROM mcr.microsoft.com/playwright:v1.59.1-noble AS builder
 
 WORKDIR /app
 
+# Origin baked into prerendered JSON-LD URL fields, RSS alternate links, etc.
+# Production builds inherit the default (https://webwhen.ai). Staging/preview
+# CI passes --build-arg PRERENDER_ORIGIN=https://staging.webwhen.ai so the
+# baked HTML doesn't point crawlers at production. See scripts/prerender.mjs.
+ARG PRERENDER_ORIGIN
+ENV PRERENDER_ORIGIN=${PRERENDER_ORIGIN}
+
 # Copy package files
 COPY package*.json ./
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/sync-changelog-fixture.mjs",
     "build": "vite build && node scripts/prerender.mjs && node scripts/generate-sitemap.mjs",
     "build:check": "tsc && vite build",
     "preview": "vite preview",

--- a/frontend/scripts/prerender.mjs
+++ b/frontend/scripts/prerender.mjs
@@ -111,4 +111,23 @@ if (failed > 0) {
   console.error(`Prerendering done with ${failed} failures.`);
   process.exit(1);
 }
+
+// Contract assertion: /changelog must ship article-level JSON-LD or the whole
+// reason this script seeds __PRERENDER_CHANGELOG__ has silently regressed.
+// Catches both fixture-missing-in-CI (the original #261 trap) and
+// React-tree-stopped-emitting (someone refactors Changelog.tsx and breaks the
+// seeded init path). Skipped when /changelog isn't in ROUTES.
+if (ROUTES.includes('/changelog')) {
+  const changelogHtml = readFileSync(join(DIST, 'changelog.html'), 'utf-8');
+  const articleCount = (changelogHtml.match(/"@type":"TechArticle"/g) ?? []).length;
+  if (articleCount < 1) {
+    console.error(
+      'Prerender postcondition failed: dist/changelog.html contains 0 TechArticle items. ' +
+      'Expected article-level JSON-LD seeded from .changelog-fixture.json. See #261.',
+    );
+    process.exit(1);
+  }
+  console.log(`  postcondition OK: /changelog has ${articleCount} TechArticle items`);
+}
+
 console.log('Prerendering complete.');

--- a/frontend/scripts/prerender.mjs
+++ b/frontend/scripts/prerender.mjs
@@ -8,7 +8,11 @@ import { loadTsModule } from './_lib/load-ts.mjs';
 const PROJECT_ROOT = join(import.meta.dirname, '..');
 const DIST = join(PROJECT_ROOT, 'dist');
 const PORT = 4567;
-const PRERENDER_ORIGIN = 'https://webwhen.ai';
+// Origin baked into JSON-LD URL fields, RSS alternate links, etc. for the
+// prerendered HTML. Production defaults to webwhen.ai; staging/preview CI
+// jobs override via PRERENDER_ORIGIN so a build for staging.webwhen.ai
+// doesn't ship HTML pointing crawlers at production.
+const PRERENDER_ORIGIN = process.env.PRERENDER_ORIGIN || 'https://webwhen.ai';
 
 // Synced from backend/static/changelog.json by scripts/sync-changelog-fixture.mjs
 // (npm `prebuild`). Lives inside the frontend build context so `docker build`
@@ -119,7 +123,7 @@ if (failed > 0) {
 // seeded init path). Skipped when /changelog isn't in ROUTES.
 if (ROUTES.includes('/changelog')) {
   const changelogHtml = readFileSync(join(DIST, 'changelog.html'), 'utf-8');
-  const articleCount = (changelogHtml.match(/"@type":"TechArticle"/g) ?? []).length;
+  const articleCount = (changelogHtml.match(/"@type":\s*"TechArticle"/g) ?? []).length;
   if (articleCount < 1) {
     console.error(
       'Prerender postcondition failed: dist/changelog.html contains 0 TechArticle items. ' +

--- a/frontend/scripts/prerender.mjs
+++ b/frontend/scripts/prerender.mjs
@@ -1,13 +1,30 @@
 import { chromium } from 'playwright';
 import handler from 'serve-handler';
 import http from 'node:http';
-import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { writeFileSync, mkdirSync, existsSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { loadTsModule } from './_lib/load-ts.mjs';
 
 const PROJECT_ROOT = join(import.meta.dirname, '..');
 const DIST = join(PROJECT_ROOT, 'dist');
 const PORT = 4567;
+const PRERENDER_ORIGIN = 'https://webwhen.ai';
+
+// Synced from backend/static/changelog.json by scripts/sync-changelog-fixture.mjs
+// (npm `prebuild`). Lives inside the frontend build context so `docker build`
+// — which cannot see `../backend/` — still bakes article-level JSON-LD into
+// dist/changelog.html. CI mirrors the host copy step before the docker build.
+const CHANGELOG_FIXTURE = join(PROJECT_ROOT, '.changelog-fixture.json');
+let changelogEntries = [];
+if (existsSync(CHANGELOG_FIXTURE)) {
+  try {
+    changelogEntries = JSON.parse(readFileSync(CHANGELOG_FIXTURE, 'utf-8'));
+  } catch (err) {
+    console.warn(`  [warn] could not parse ${CHANGELOG_FIXTURE}: ${err.message}`);
+  }
+} else {
+  console.warn(`  [warn] ${CHANGELOG_FIXTURE} missing; /changelog JSON-LD will lack article items`);
+}
 
 // Ensure config.js exists (normally injected at runtime by nginx)
 const configPath = join(DIST, 'config.js');
@@ -34,10 +51,17 @@ console.log(`Prerendering ${ROUTES.length} routes...`);
 
 const context = await browser.newContext();
 
-// Bypass auth during prerendering — app checks this flag to use NoAuthProvider
-await context.addInitScript(() => {
-  window.__PRERENDER__ = true;
-});
+// Bypass auth during prerendering, and seed build-time fixtures the React
+// tree consumes synchronously so route HTML bakes in JSON-LD that would
+// otherwise depend on a runtime fetch (e.g. /changelog).
+await context.addInitScript(
+  ([entries, origin]) => {
+    window.__PRERENDER__ = true;
+    window.__PRERENDER_ORIGIN__ = origin;
+    window.__PRERENDER_CHANGELOG__ = entries;
+  },
+  [changelogEntries, PRERENDER_ORIGIN],
+);
 
 let failed = 0;
 
@@ -60,8 +84,12 @@ for (const route of ROUTES) {
     continue;
   }
 
-  // Remove prerender flag from output HTML so it doesn't affect real users
-  await page.evaluate(() => { delete window.__PRERENDER__; });
+  // Strip prerender globals from output HTML so they don't affect real users
+  await page.evaluate(() => {
+    delete window.__PRERENDER__;
+    delete window.__PRERENDER_ORIGIN__;
+    delete window.__PRERENDER_CHANGELOG__;
+  });
 
   const html = await page.content();
   const outPath =

--- a/frontend/scripts/sync-changelog-fixture.mjs
+++ b/frontend/scripts/sync-changelog-fixture.mjs
@@ -1,0 +1,24 @@
+// Copies backend/static/changelog.json into the frontend build context as
+// .changelog-fixture.json so scripts/prerender.mjs can bake article-level
+// JSON-LD into dist/changelog.html. The fixture is gitignored; CI also runs
+// this step (or an equivalent cp) before `docker build` because the frontend
+// image build context is just `frontend/` and cannot reach `../backend/`.
+//
+// Missing fixture is non-fatal: prerender falls back to an empty entries list,
+// which produces the CollectionPage shell without TechArticle items, matching
+// pre-fix behaviour.
+import { copyFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PROJECT_ROOT = join(import.meta.dirname, '..');
+const SRC = join(PROJECT_ROOT, '..', 'backend', 'static', 'changelog.json');
+const DEST = join(PROJECT_ROOT, '.changelog-fixture.json');
+
+if (!existsSync(SRC)) {
+  console.warn(`[sync-changelog-fixture] source missing at ${SRC}; skipping. ` +
+    `Prerendered /changelog will not include article-level JSON-LD.`);
+  process.exit(0);
+}
+
+copyFileSync(SRC, DEST);
+console.log(`[sync-changelog-fixture] ${SRC} → ${DEST}`);

--- a/frontend/src/components/Changelog.tsx
+++ b/frontend/src/components/Changelog.tsx
@@ -18,10 +18,23 @@ const CATEGORY_LABELS: Record<ChangelogEntry["category"], string> = {
   research: "research",
 };
 
+// At prerender time `scripts/prerender.mjs` seeds the changelog fixture on
+// `window` so the very first render emits the article-level JSON-LD into the
+// baked HTML. Real users still get the runtime fetch below.
+function readPrerenderEntries(): ChangelogEntry[] {
+  if (typeof window === "undefined") return [];
+  const seeded = (window as unknown as { __PRERENDER_CHANGELOG__?: ChangelogEntry[] })
+    .__PRERENDER_CHANGELOG__;
+  return Array.isArray(seeded) ? seeded : [];
+}
+
 export default function Changelog() {
-  const [entries, setEntries] = useState<ChangelogEntry[]>([]);
-  const [structuredData, setStructuredData] = useState<string>("");
-  const [loading, setLoading] = useState(true);
+  const seeded = readPrerenderEntries();
+  const [entries, setEntries] = useState<ChangelogEntry[]>(seeded);
+  const [structuredData, setStructuredData] = useState<string>(() =>
+    seeded.length ? JSON.stringify(generateChangelogStructuredData(seeded)) : "",
+  );
+  const [loading, setLoading] = useState(seeded.length === 0);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {

--- a/frontend/src/components/Changelog.tsx
+++ b/frontend/src/components/Changelog.tsx
@@ -29,6 +29,23 @@ function readPrerenderEntries(): ChangelogEntry[] {
   return Array.isArray(seeded) ? seeded : [];
 }
 
+// Escape contract for inline JSON-LD inside a <script> tag. `<` blocks any
+// closing-tag literal forming inside the body. `/` breaks any `</script>` an
+// entry could smuggle. U+2028 and U+2029 are legal in JSON but illegal in
+// pre-ES2019 JS string literals (historic XSS vector). Source is trusted
+// today (we author changelog.json); the escape is the serialization-boundary
+// contract, not user-input defence. Built via fromCharCode so source files
+// stay free of literal U+2028/U+2029 that some tooling silently normalises.
+const LS = String.fromCharCode(0x2028);
+const PS = String.fromCharCode(0x2029);
+function escapeForScriptTag(json: string): string {
+  return json
+    .replace(/</g, "\\u003c")
+    .replace(/\//g, "\\/")
+    .split(LS).join("\\u2028")
+    .split(PS).join("\\u2029");
+}
+
 export default function Changelog() {
   const rssHref = `${getOrigin()}/changelog.xml`;
   const seeded = readPrerenderEntries();
@@ -85,7 +102,7 @@ export default function Changelog() {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: structuredData.replace(/</g, "\\u003c"),
+            __html: escapeForScriptTag(structuredData),
           }}
         />
       )}

--- a/frontend/src/components/Changelog.tsx
+++ b/frontend/src/components/Changelog.tsx
@@ -5,6 +5,7 @@ import { DynamicMeta } from "@/components/DynamicMeta";
 import { ChangelogEntry } from "@/types/changelog";
 import { formatChangelogDate } from "@/utils/changelog";
 import { generateChangelogStructuredData } from "@/utils/structuredData";
+import { getOrigin } from "@/utils/origin";
 import { cn } from "@/lib/utils";
 import api from "@/lib/api";
 import landingStyles from "@/components/landing/Landing.module.css";
@@ -29,6 +30,7 @@ function readPrerenderEntries(): ChangelogEntry[] {
 }
 
 export default function Changelog() {
+  const rssHref = `${getOrigin()}/changelog.xml`;
   const seeded = readPrerenderEntries();
   const [entries, setEntries] = useState<ChangelogEntry[]>(seeded);
   const [structuredData, setStructuredData] = useState<string>(() =>
@@ -37,6 +39,10 @@ export default function Changelog() {
   const [loading, setLoading] = useState(seeded.length === 0);
   const [error, setError] = useState<string | null>(null);
 
+  // Runtime fetch refreshes the prerender-seeded entries with fresh data.
+  // Crawlers read the baked JSON-LD from raw HTML pre-hydration; users see no
+  // visible JSON-LD either way, so the brief window where DOM holds the
+  // fixture-shape script tag before this resolves is benign. See #261.
   useEffect(() => {
     const fetchChangelog = async () => {
       try {
@@ -72,7 +78,7 @@ export default function Changelog() {
           rel="alternate"
           type="application/rss+xml"
           title="webwhen changelog"
-          href="https://torale.ai/changelog.xml"
+          href={rssHref}
         />
       </Helmet>
       {structuredData && (

--- a/frontend/src/utils/origin.ts
+++ b/frontend/src/utils/origin.ts
@@ -1,0 +1,19 @@
+const FALLBACK_ORIGIN = "https://webwhen.ai";
+
+/**
+ * Resolve the origin used in baked URLs (JSON-LD, RSS alternate links, etc.).
+ * Runtime in the browser uses the document origin so any future domain
+ * transition self-references correctly. Prerender time uses
+ * `window.__PRERENDER_ORIGIN__` injected by `scripts/prerender.mjs` because
+ * `window.location` is the local headless server. SSR / non-window contexts
+ * fall back to webwhen.ai. See #261 + #246.
+ */
+export function getOrigin(): string {
+  if (typeof window === "undefined") return FALLBACK_ORIGIN;
+  const w = window as unknown as {
+    __PRERENDER_ORIGIN__?: string;
+    __PRERENDER__?: boolean;
+  };
+  if (w.__PRERENDER__ && w.__PRERENDER_ORIGIN__) return w.__PRERENDER_ORIGIN__;
+  return window.location.origin || FALLBACK_ORIGIN;
+}

--- a/frontend/src/utils/structuredData.ts
+++ b/frontend/src/utils/structuredData.ts
@@ -1,24 +1,5 @@
 import { ChangelogEntry } from "@/types/changelog";
-
-const FALLBACK_ORIGIN = "https://webwhen.ai";
-
-/**
- * Resolve the origin used in JSON-LD URL fields. At runtime in the browser we
- * use the document origin so torale.ai-served pages self-reference correctly
- * during any future domain transition. At prerender time `window.location` is
- * the local headless server, so `scripts/prerender.mjs` injects
- * `__PRERENDER_ORIGIN__` with the production origin to bake into static HTML.
- * SSR / non-window contexts fall back to webwhen.ai.
- */
-function getOrigin(): string {
-  if (typeof window === "undefined") return FALLBACK_ORIGIN;
-  const w = window as unknown as {
-    __PRERENDER_ORIGIN__?: string;
-    __PRERENDER__?: boolean;
-  };
-  if (w.__PRERENDER__ && w.__PRERENDER_ORIGIN__) return w.__PRERENDER_ORIGIN__;
-  return window.location.origin || FALLBACK_ORIGIN;
-}
+import { getOrigin } from "@/utils/origin";
 
 export interface FAQItem {
   question: string;

--- a/frontend/src/utils/structuredData.ts
+++ b/frontend/src/utils/structuredData.ts
@@ -1,5 +1,25 @@
 import { ChangelogEntry } from "@/types/changelog";
 
+const FALLBACK_ORIGIN = "https://webwhen.ai";
+
+/**
+ * Resolve the origin used in JSON-LD URL fields. At runtime in the browser we
+ * use the document origin so torale.ai-served pages self-reference correctly
+ * during any future domain transition. At prerender time `window.location` is
+ * the local headless server, so `scripts/prerender.mjs` injects
+ * `__PRERENDER_ORIGIN__` with the production origin to bake into static HTML.
+ * SSR / non-window contexts fall back to webwhen.ai.
+ */
+function getOrigin(): string {
+  if (typeof window === "undefined") return FALLBACK_ORIGIN;
+  const w = window as unknown as {
+    __PRERENDER_ORIGIN__?: string;
+    __PRERENDER__?: boolean;
+  };
+  if (w.__PRERENDER__ && w.__PRERENDER_ORIGIN__) return w.__PRERENDER_ORIGIN__;
+  return window.location.origin || FALLBACK_ORIGIN;
+}
+
 export interface FAQItem {
   question: string;
   answer: string;
@@ -21,19 +41,20 @@ export function generateFAQStructuredData(items: FAQItem[]) {
 }
 
 export function generateChangelogStructuredData(entries: ChangelogEntry[]) {
+  const origin = getOrigin();
   return {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
     "name": "webwhen Changelog",
-    "description": "Product updates and releases for webwhen — the AI agent that watches the open web and tells you when something matters.",
-    "url": "https://webwhen.ai/changelog",
+    "description": "Product updates and releases for webwhen, the AI agent that watches the open web and tells you when something matters.",
+    "url": `${origin}/changelog`,
     "publisher": {
       "@type": "Organization",
       "name": "webwhen",
-      "url": "https://webwhen.ai",
+      "url": origin,
       "logo": {
         "@type": "ImageObject",
-        "url": "https://webwhen.ai/brand/webwhen-mark.svg",
+        "url": `${origin}/brand/webwhen-mark.svg`,
         "width": 512,
         "height": 512
       },
@@ -72,13 +93,13 @@ export function generateChangelogStructuredData(entries: ChangelogEntry[]) {
           "@type": "ListItem",
           "position": 1,
           "name": "Home",
-          "item": "https://webwhen.ai"
+          "item": origin
         },
         {
           "@type": "ListItem",
           "position": 2,
           "name": "Changelog",
-          "item": "https://webwhen.ai/changelog"
+          "item": `${origin}/changelog`
         }
       ]
     }


### PR DESCRIPTION
## Summary

Closes #261. Crawlers now read article-level JSON-LD directly from raw `dist/changelog.html` — no JS execution required. Real users still hydrate normally and refresh entries via runtime fetch.

## How it works

- `frontend/scripts/sync-changelog-fixture.mjs` (new, `prebuild`) copies `backend/static/changelog.json` → `frontend/.changelog-fixture.json`. The frontend Docker build context can't reach `../backend/`, so the fixture has to live inside the context.
- `frontend/scripts/prerender.mjs` reads the fixture at build time and seeds `window.__PRERENDER_CHANGELOG__` + `window.__PRERENDER_ORIGIN__` via `addInitScript`. The React tree consumes these synchronously so the very first render emits the JSON-LD into the captured HTML.
- `frontend/src/components/Changelog.tsx` initialises state from the seeded globals when present. Runtime fetch path unchanged for real users.
- `frontend/src/utils/structuredData.ts` now resolves origin via a shared `getOrigin()` helper: `__PRERENDER_ORIGIN__` (build) → `window.location.origin` (runtime) → `https://webwhen.ai` fallback. RSS `<link rel="alternate">` migrated from a hardcoded `https://torale.ai` to the same helper.
- `.github/workflows/{production,staging}.yml`: conditional `cp backend/static/changelog.json frontend/.changelog-fixture.json` step before the docker build, gated on `matrix.component == 'frontend'`.
- `frontend/Dockerfile`: `ARG PRERENDER_ORIGIN` + `ENV PRERENDER_ORIGIN` in the builder stage. `staging.yml` passes `--build-arg PRERENDER_ORIGIN=https://staging.torale.ai`. Production inherits the default. Closes #275 in spirit but the residual `generate-sitemap.mjs:8` one-liner is in a separate branch.

## Hardening (round 2)

- **JSON-LD inline-script escape** — extracted to `escapeForScriptTag()` helper. Adds forward-slash escape (`\\/`) to break any `</script>` an entry could smuggle, plus U+2028/U+2029 escapes (legal in JSON, illegal in pre-ES2019 JS string literals — historic XSS vector). Source is trusted today; the escape is the serialization-boundary contract, not user-input defence.
- **Postcondition assertion in `prerender.mjs`** — re-reads `dist/changelog.html` post-prerender and counts `"@type":\\s*"TechArticle"` matches. Fails the build with a clear message if zero. Catches both fixture-missing-in-CI (the original #261 trap) and React-tree-stopped-emitting (someone refactors `Changelog.tsx` and breaks the seeded init path). Tests the contract end-to-end at the artefact level.
- **Staging origin bug** — without env-overridable origin, staging builds (deployed at `staging.torale.ai`) would have shipped JSON-LD/RSS/canonical pointing crawlers at production. Same class as the soak self-canonical bug from phase 7, inverted.

## Verified locally

- Default `npm run build`: `dist/changelog.html` URLs all `https://webwhen.ai`, postcondition logs 50 TechArticle items
- `PRERENDER_ORIGIN=https://staging.torale.ai npm run build`: URLs all `https://staging.torale.ai`, postcondition OK
- `__PRERENDER_*` globals don't leak into baked HTML (window props, not DOM)
- `just lint` clean
- Forward slashes escaped in baked JSON-LD
- 12 prerendered HTML files, no other route regressions

## Test plan

- [ ] CI build passes (postcondition assertion catches absent fixture)
- [ ] Staging deploy: `curl https://staging.torale.ai/changelog | grep '"@type":"TechArticle"'` returns 50 hits, all URLs scoped to `staging.torale.ai`
- [ ] Production deploy: same check on `webwhen.ai`, all URLs scoped to `webwhen.ai`
- [ ] Runtime hydration: real user on `/changelog` sees live data (runtime fetch refreshes seeded entries)

## Authorship + history note

This branch was authored on a worktree by `torale.feat-prerender-claude-code`, who went offline pre-PR-open due to a repowire ws-hook silent deregistration (memoised in this project's auto-memory as `reference_repowire_ws_hook.md`). Per orchestrator coordination (notif-99540ef3), this PR is opened on the work's behalf — branch is the artifact, author lifecycle decoupled. Round 1 review: notif-91b0ed90 → notif-8af33061. Round 2 review on ad58c28 was approve-ready.

## Related

- Closes #261
- Cross-link to #275 (staging canonical bug filed during round 2; full closure needs the residual `generate-sitemap.mjs` one-liner which is on a separate branch)