### PR TITLE
fix(helm): noindex header on staging.torale.ai catchall

### DIFF
--- a/helm/torale/templates/httproute.yaml
+++ b/helm/torale/templates/httproute.yaml
@@ -95,6 +95,19 @@ spec:
     - path:
         type: PathPrefix
         value: /
+    {{- if .Values.httproute.stagingNoindex }}
+    # Belt-and-suspenders alongside the backend's robots.txt Disallow:
+    # X-Robots-Tag handles crawlers that ignore robots.txt. Set in
+    # values-staging.yaml only — production never serves the torale routes
+    # as a backend (it 301s via httproute.cutover above), so this branch
+    # never renders for production.
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Robots-Tag
+          value: "noindex, nofollow"
+    {{- end }}
     backendRefs:
     - group: ""
       kind: Service

--- a/helm/torale/values-staging.yaml
+++ b/helm/torale/values-staging.yaml
@@ -59,3 +59,9 @@ database:
 # Disable docs for staging
 docs:
   enabled: false
+
+# Keep staging out of search indices. Backend's /robots.txt already serves
+# `Disallow: /` but X-Robots-Tag covers crawlers that ignore robots.txt.
+# Closes #280.
+httproute:
+  stagingNoindex: true

--- a/helm/torale/values.yaml
+++ b/helm/torale/values.yaml
@@ -247,6 +247,11 @@ httproute:
   # remove the values-webwhen-soak.yaml overlay (or set this to false).
   # Has no effect when domains.webwhen is unset (no webwhen routes render).
   noindex: false
+  # Inject `X-Robots-Tag: noindex, nofollow` on the torale-route frontend
+  # catchall. Set true in values-staging.yaml so staging.torale.ai isn't
+  # crawlable. Production sets httproute.cutover=true which 301-redirects
+  # the torale routes entirely, so this flag has no effect there. See #280.
+  stagingNoindex: false
 
 # webwhen.ai parallel routing (rebrand cutover).
 #


### PR DESCRIPTION
Closes #280.

## Summary

`staging.torale.ai` was serving HTTP 200 with no `X-Robots-Tag: noindex` header — the soak-era noindex was retired with cutover but staging is still live on torale.ai (staging.webwhen.ai doesn't exist; #281 tracks the strategic migration).

Backend's `/robots.txt` already serves `Disallow: /` so well-behaved crawlers respect it; this is belt-and-suspenders for crawlers that ignore robots.txt.

## Change

- `helm/torale/templates/httproute.yaml`: add `ResponseHeaderModifier` filter on the torale-route frontend catchall when `httproute.stagingNoindex` is true. Wrapped in the existing `else` branch of the cutover conditional, so production (cutover=true) is untouched.
- `helm/torale/values.yaml`: declare `httproute.stagingNoindex: false` default with comment.
- `helm/torale/values-staging.yaml`: set `httproute.stagingNoindex: true`.

## Verified locally

`helm template torale helm/torale -f values.yaml -f values-staging.yaml` renders the filter on the staging catchall. Production rendering unchanged (still 301 RequestRedirect via the cutover branch).

## Deploy plan

Ship via `deploy` label after merge. Smoke: `curl -sS -D - -o /dev/null https://staging.torale.ai/changelog | grep x-robots-tag` should show `noindex, nofollow` post-deploy.