### PR TITLE
fix(seo): env-overridable sitemap origin, default webwhen.ai

### DIFF
--- a/frontend/scripts/generate-sitemap.mjs
+++ b/frontend/scripts/generate-sitemap.mjs
@@ -5,7 +5,10 @@ import { loadTsModule } from './_lib/load-ts.mjs';
 
 const PROJECT_ROOT = join(import.meta.dirname, '..');
 const DIST = join(PROJECT_ROOT, 'dist');
-const SITE_ORIGIN = 'https://torale.ai';
+// Origin baked into <loc> entries. Production defaults to webwhen.ai;
+// staging/preview CI jobs override via PRERENDER_ORIGIN (shared with
+// prerender.mjs) so a staging sitemap doesn't point crawlers at production.
+const SITE_ORIGIN = process.env.PRERENDER_ORIGIN || 'https://webwhen.ai';
 
 const { PUBLIC_ROUTES } = await loadTsModule(join(PROJECT_ROOT, 'src/data/publicRoutes.ts'));
 


### PR DESCRIPTION
Closes #275.

## Summary

Sister fix to #276's prerender PR. `frontend/scripts/generate-sitemap.mjs` had a hardcoded `https://torale.ai` origin (now wrong post-cutover, and silently bakes prod URL on staging builds the same way #261's CollectionPage JSON-LD did before #276). Mirrors the prerender pattern exactly: `process.env.PRERENDER_ORIGIN || 'https://webwhen.ai'`.

## Change

Single line + a 3-line comment in `generate-sitemap.mjs`. Reads `PRERENDER_ORIGIN` env var with `https://webwhen.ai` fallback. Production builds inherit the default; staging.yml passes `--build-arg PRERENDER_ORIGIN=https://staging.torale.ai` (already plumbed by #276's Dockerfile + workflow changes).

## Verified locally (peer-reported)

1. Clean rebase onto current main (post-#279 hotfix, post-#276 prerender)
2. `npm ci`: 534 packages, 0 vulns, lockfile compat ✓
3. `npm run build`: full pipeline green, prerender postcondition `OK: /changelog has 50 TechArticle items`, 12 routes written
4. **Default origin smoke**: 12/12 sitemap entries on `https://webwhen.ai`, 0 stale `torale.ai`
5. **Staging override smoke**: `PRERENDER_ORIGIN=https://staging.torale.ai node scripts/generate-sitemap.mjs` → 12/12 on `staging.torale.ai`, 0 leakage

## Authorship

Authored by `torale.fix-staging-url-claude-code` peer. PR opened on their behalf per orchestrator-coordinated merge train compression (notif-809c8cf7) — same pattern as #276 (work is the artifact, peer lifecycle decoupled).

## Related

- Closes #275 (filed during #261 round 2 review)
- Sister to #276 (now merged)
- Rebrand milestone (#9)