### PR TITLE
P0 fix(csp): allow challenges.cloudflare.com for Clerk Turnstile signup CAPTCHA

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -33,11 +33,16 @@ server {
     #   for the rebrand cutover (Clerk primary domain flipped 2026-05-03;
     #   old clerk.torale.ai may still serve briefly during DNS propagation).
     #   Strip clerk.torale.ai post-cutover when DNS settles.
+    # - script-src + frame-src admit challenges.cloudflare.com for Clerk's
+    #   Bot Protection (Cloudflare Turnstile). The widget script + iframe
+    #   both load from this origin; without it CAPTCHA fails to render and
+    #   signup is blocked. Discovered post-cutover when user reported sign-up
+    #   spinner stuck on iPhone.
     more_set_headers "X-Content-Type-Options: nosniff";
     more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload";
     more_set_headers "Referrer-Policy: strict-origin-when-cross-origin";
     more_set_headers "Permissions-Policy: geolocation=(), microphone=(), camera=()";
-    more_set_headers "Content-Security-Policy: default-src 'self'; script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://clerk.torale.ai https://clerk.webwhen.ai https://static.cloudflareinsights.com https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://*.clerk.com https://*.torale.ai https://*.webwhen.ai; connect-src 'self' https://*.torale.ai https://*.webwhen.ai https://*.clerk.accounts.dev https://*.clerk.com https://api.clerk.com https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com; frame-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://clerk.torale.ai https://clerk.webwhen.ai; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self';";
+    more_set_headers "Content-Security-Policy: default-src 'self'; script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://clerk.torale.ai https://clerk.webwhen.ai https://challenges.cloudflare.com https://static.cloudflareinsights.com https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://*.clerk.com https://*.torale.ai https://*.webwhen.ai; connect-src 'self' https://*.torale.ai https://*.webwhen.ai https://*.clerk.accounts.dev https://*.clerk.com https://api.clerk.com https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com; frame-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://clerk.torale.ai https://clerk.webwhen.ai https://challenges.cloudflare.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self';";
 
     rewrite ^/(.+)/$ /$1 permanent;
 


### PR DESCRIPTION
## P0 — signup CAPTCHA failing on webwhen.ai

User reported sign-up form stuck on spinner with "The CAPTCHA failed to load. This may be due to an unsupported browser or a browser extension." Affects every new-customer signup.

## Root cause

CSP \`script-src\` and \`frame-src\` directives are missing \`https://challenges.cloudflare.com\`. Clerk's Bot Protection uses Cloudflare Turnstile, which loads its widget script + renders its iframe from \`challenges.cloudflare.com\`. The CSP that #259's headers-more migration shipped covered Clerk's own domains (\`*.clerk.com\`, \`clerk.webwhen.ai\`) but not Turnstile's origin.

Verified diagnosis: \`curl -sS -D - -o /dev/null https://webwhen.ai/ | grep content-security-policy\` shows the missing entries.

## Fix

Add \`https://challenges.cloudflare.com\` to both \`script-src\` and \`frame-src\` in \`frontend/nginx.conf\`. One-line directive change + a 5-line comment explaining why (so this doesn't get stripped in a future cleanup pass).

## Test plan

- [ ] CI build + production deploy
- [ ] T+5min smoke: \`curl -sS -D - -o /dev/null https://webwhen.ai/ | grep content-security-policy\` shows \`challenges.cloudflare.com\` in script-src + frame-src
- [ ] Visual confirmation: load https://webwhen.ai/sign-up, CAPTCHA renders, no console CSP errors
- [ ] iPhone retest by user

## Related

- Discovered via user report 2026-05-04 ~13:00Z
- Likely regression from #259 headers-more migration (enforce-mode CSP) which didn't include Turnstile-specific entries
- This is a hotfix; firing deploy label immediately on merge