### PR TITLE
chore(helm): rename domains schema to legacy/live + checksum annotation (#270)

### DIFF
--- a/helm/torale/templates/api-deployment.yaml
+++ b/helm/torale/templates/api-deployment.yaml
@@ -14,6 +14,15 @@ spec:
       {{- include "torale.api.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        # Roll API pods on ConfigMap-only changes. Without this, a
+        # config-only Helm sync (same image tag, different ConfigMap) does
+        # NOT restart the api Deployment because envFrom doesn't propagate.
+        # Frontend's config.js is volume-mounted and picks up changes
+        # without a restart, but the backend reads via envFrom — so a
+        # remediation that only touches values needs this annotation to
+        # actually take effect. Surfaced during #270 review.
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "torale.api.selectorLabels" . | nindent 8 }}
     spec:

--- a/helm/torale/templates/configmap.yaml
+++ b/helm/torale/templates/configmap.yaml
@@ -18,13 +18,13 @@ data:
   AGENT_URL: {{ printf "http://%s-agent-free" (include "torale.fullname" .) | quote }}
 
   # API + frontend self-URLs (used for email links, OAuth callbacks, etc.).
-  # Post-cutover (production), the live hosts are .Values.domains.webwhen.*;
-  # the legacy .Values.domains.{api,frontend} are pinned to torale.ai as the
-  # 301-redirect source in httproute.yaml. On surfaces with no parallel-route
-  # setup (staging, dev), domains.webwhen is absent and the legacy keys ARE
-  # the live hosts.
-  API_URL: {{ printf "https://%s" (default .Values.domains.api (dig "webwhen" "api" "" .Values.domains)) | quote }}
-  FRONTEND_URL: {{ printf "https://%s" (default .Values.domains.frontend (dig "webwhen" "frontend" "" .Values.domains)) | quote }}
+  # Post-cutover (production), the live hosts are .Values.domains.live.*;
+  # .Values.domains.legacy.* is pinned to torale.ai as the 301-redirect
+  # source in httproute.yaml. On surfaces with no parallel-route setup
+  # (staging, dev), domains.live is absent and the legacy keys ARE the
+  # live hosts — the dig fallback below handles that.
+  API_URL: {{ printf "https://%s" (default .Values.domains.legacy.api (dig "live" "api" "" .Values.domains)) | quote }}
+  FRONTEND_URL: {{ printf "https://%s" (default .Values.domains.legacy.frontend (dig "live" "frontend" "" .Values.domains)) | quote }}
 
   # Platform capacity
   MAX_USERS: {{ .Values.capacity.maxUsers | quote }}

--- a/helm/torale/templates/frontend-config.yaml
+++ b/helm/torale/templates/frontend-config.yaml
@@ -1,12 +1,12 @@
 {{- if .Values.frontend.enabled -}}
 {{- /*
 Live API hostname. Post-cutover (production), the live host is
-.Values.domains.webwhen.api; the legacy .Values.domains.api is pinned to
-torale.ai as the 301-redirect source (see httproute.yaml). On surfaces with
-no parallel-route setup (staging, dev, default chart values), domains.webwhen
-is absent and the legacy key IS the live host. Fall back accordingly.
+.Values.domains.live.api; .Values.domains.legacy.api is pinned to torale.ai
+as the 301-redirect source (see httproute.yaml). On surfaces with no
+parallel-route setup (staging, dev, default chart values), domains.live is
+absent and the legacy key IS the live host. Fall back accordingly.
 */ -}}
-{{- $apiHost := default .Values.domains.api (dig "webwhen" "api" "" .Values.domains) -}}
+{{- $apiHost := default .Values.domains.legacy.api (dig "live" "api" "" .Values.domains) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/torale/templates/httproute.yaml
+++ b/helm/torale/templates/httproute.yaml
@@ -30,7 +30,7 @@ spec:
     name: {{ .Values.httproute.gatewayName }}
     namespace: clusterkit
   hostnames:
-  - {{ .Values.domains.frontend | quote }}
+  - {{ .Values.domains.legacy.frontend | quote }}
   rules:
   {{- if $isCutover }}
   # T-0 cutover: 301 redirect torale.ai/* → webwhen.ai/* (path preserved)
@@ -42,7 +42,7 @@ spec:
     - type: RequestRedirect
       requestRedirect:
         scheme: https
-        hostname: {{ .Values.domains.webwhen.frontend | quote }}
+        hostname: {{ .Values.domains.live.frontend | quote }}
         statusCode: 301
   {{- else }}
   # SEO endpoints served by backend API (must be before frontend catchall)
@@ -135,7 +135,7 @@ spec:
     name: {{ .Values.httproute.gatewayName }}
     namespace: clusterkit
   hostnames:
-  - {{ .Values.domains.api | quote }}
+  - {{ .Values.domains.legacy.api | quote }}
   rules:
   {{- if $isCutover }}
   # T-0 cutover: 301 redirect api.torale.ai/* → api.webwhen.ai/* (path preserved)
@@ -147,7 +147,7 @@ spec:
     - type: RequestRedirect
       requestRedirect:
         scheme: https
-        hostname: {{ .Values.domains.webwhen.api | quote }}
+        hostname: {{ .Values.domains.live.api | quote }}
         statusCode: 301
   {{- else }}
   - matches:
@@ -182,7 +182,7 @@ spec:
     name: {{ .Values.httproute.gatewayName }}
     namespace: clusterkit
   hostnames:
-  - {{ .Values.domains.docs | quote }}
+  - {{ .Values.domains.legacy.docs | quote }}
   rules:
   {{- if $isCutover }}
   # T-0 cutover: 301 redirect docs.torale.ai/* → docs.webwhen.ai/* (path preserved)
@@ -194,7 +194,7 @@ spec:
     - type: RequestRedirect
       requestRedirect:
         scheme: https
-        hostname: {{ .Values.domains.webwhen.docs | quote }}
+        hostname: {{ .Values.domains.live.docs | quote }}
         statusCode: 301
   {{- else }}
   - matches:
@@ -214,7 +214,7 @@ spec:
 # ============================================================================
 # webwhen.ai parallel routes (rebrand cutover)
 # ----------------------------------------------------------------------------
-# These render only when .Values.domains.webwhen is set (soak overlay or
+# These render only when .Values.domains.live is set (soak overlay or
 # cutover values). Until then the chart deploys the torale.ai routes only.
 #
 # During the soak window (T-2d → T-0): set .Values.httproute.noindex=true to
@@ -256,7 +256,7 @@ spec:
 #    when no record exists. Verify cleanup via Cloudflare API
 #    (`count=0` on the records endpoint), never via dig.
 # ============================================================================
-{{- if .Values.domains.webwhen }}
+{{- if .Values.domains.live }}
 ---
 # webwhen frontend HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1
@@ -276,7 +276,7 @@ spec:
     name: {{ .Values.httproute.gatewayName }}
     namespace: clusterkit
   hostnames:
-  - {{ .Values.domains.webwhen.frontend | quote }}
+  - {{ .Values.domains.live.frontend | quote }}
   rules:
   - matches:
     - path:
@@ -392,7 +392,7 @@ spec:
     name: {{ .Values.httproute.gatewayName }}
     namespace: clusterkit
   hostnames:
-  - {{ .Values.domains.webwhen.api | quote }}
+  - {{ .Values.domains.live.api | quote }}
   rules:
   - matches:
     - path:
@@ -413,7 +413,7 @@ spec:
       namespace: {{ $serviceNamespace }}
       port: {{ .Values.api.service.port }}
       weight: 1
-{{- if and .Values.docs.enabled .Values.domains.webwhen.docs }}
+{{- if and .Values.docs.enabled .Values.domains.live.docs }}
 ---
 # webwhen Docs HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1
@@ -433,7 +433,7 @@ spec:
     name: {{ .Values.httproute.gatewayName }}
     namespace: clusterkit
   hostnames:
-  - {{ .Values.domains.webwhen.docs | quote }}
+  - {{ .Values.domains.live.docs | quote }}
   rules:
   - matches:
     - path:
@@ -455,7 +455,7 @@ spec:
       port: {{ .Values.docs.service.port }}
       weight: 1
 {{- end }}
-{{- if and (not $isStagingRelease) .Values.domains.webwhen.www }}
+{{- if and (not $isStagingRelease) .Values.domains.live.www }}
 ---
 # www.webwhen.ai → apex 301 redirect
 # Production-only (no www-staging hostname). Redirect-only HTTPRoute carries
@@ -477,7 +477,7 @@ spec:
     name: {{ .Values.httproute.gatewayName }}
     namespace: clusterkit
   hostnames:
-  - {{ .Values.domains.webwhen.www | quote }}
+  - {{ .Values.domains.live.www | quote }}
   rules:
   - matches:
     - path:
@@ -487,7 +487,7 @@ spec:
     - type: RequestRedirect
       requestRedirect:
         scheme: https
-        hostname: {{ .Values.domains.webwhen.frontend | quote }}
+        hostname: {{ .Values.domains.live.frontend | quote }}
         statusCode: 301
 {{- end }}
 {{- end }}

--- a/helm/torale/values-production.yaml
+++ b/helm/torale/values-production.yaml
@@ -1,14 +1,16 @@
 # Production values for Torale on GKE ClusterKit
 
 domains:
-  frontend: torale.ai
-  api: api.torale.ai
   # webwhen.ai cutover (T-0, 2026-05-03):
   # webwhen routes now ship with the production chart (no soak overlay).
   # noindex flag is OFF (httproute.noindex: false) so webwhen.ai is
   # crawlable. The torale routes are flipped to 301 RequestRedirect via
   # the chart template's $isCutover branch.
-  webwhen:
+  legacy:
+    frontend: torale.ai
+    api: api.torale.ai
+    docs: docs.torale.ai
+  live:
     frontend: webwhen.ai
     www: www.webwhen.ai
     api: api.webwhen.ai

--- a/helm/torale/values-staging.yaml
+++ b/helm/torale/values-staging.yaml
@@ -2,9 +2,12 @@
 # Deployed to staging.torale.ai for pre-production testing
 
 domains:
-  frontend: staging.torale.ai
-  api: api-staging.torale.ai
-  docs: docs-staging.torale.ai
+  # Staging has no parallel webwhen routes; legacy IS the live hostname.
+  # See #270 for the schema rationale.
+  legacy:
+    frontend: staging.torale.ai
+    api: api-staging.torale.ai
+    docs: docs-staging.torale.ai
 
 # Clerk authentication (uses production Clerk app - same as production)
 # Rotated 2026-05-03 alongside production for the webwhen.ai rebrand cutover.

--- a/helm/torale/values-webwhen-soak.yaml
+++ b/helm/torale/values-webwhen-soak.yaml
@@ -39,7 +39,7 @@ httproute:
   noindex: true
 
 domains:
-  webwhen:
+  live:
     # Production hostnames. Override in a staging-soak overlay (or invoke
     # helmfile with values-staging.yaml + this file, then override frontend
     # and api keys to the staging variants) for the staging soak.

--- a/helm/torale/values.yaml
+++ b/helm/torale/values.yaml
@@ -7,10 +7,27 @@ global:
   region: us-central1
 
 # Domain configuration
+#
+# Two-tier schema (renamed in #270 to remove the cutover-time semantic flip
+# that bit #268). Read this before adding a hostname reference:
+#
+# - domains.legacy.*  the redirect-source hostnames. Post-cutover these are
+#                     pinned to torale.ai and serve 301 RequestRedirect to
+#                     domains.live.* in httproute.yaml. Pre-cutover (and on
+#                     surfaces with no live block — staging, dev), legacy
+#                     IS the customer-facing hostname; the templates fall
+#                     back via `dig "live" ... .Values.domains`.
+# - domains.live.*    the customer-facing hostnames post-cutover. Set in
+#                     values-production.yaml. Absent in staging/dev.
+#
+# Consumer-site rule: if you want the live hostname, read
+# `dig "live" "<key>" "" .Values.domains` with a fallback to legacy. If you
+# want the redirect source specifically, read .Values.domains.legacy.*.
 domains:
-  frontend: torale.ai
-  api: api.torale.ai
-  docs: docs.torale.ai
+  legacy:
+    frontend: torale.ai
+    api: api.torale.ai
+    docs: docs.torale.ai
 
 # Clerk authentication
 clerk:
@@ -263,7 +280,7 @@ httproute:
 #
 # Production overlay shape:
 #   domains:
-#     webwhen:
+#     live:
 #       frontend: webwhen.ai
 #       www: www.webwhen.ai
 #       api: api.webwhen.ai
@@ -271,11 +288,11 @@ httproute:
 #
 # Staging overlay shape (no www, no docs):
 #   domains:
-#     webwhen:
+#     live:
 #       frontend: staging.webwhen.ai
 #       api: api-staging.webwhen.ai
 #
-# domains.webwhen: {}  # leave commented; overlays set this
+# domains.live: {}  # leave commented; overlays set this
 
 # ConfigMap for non-sensitive configuration
 config:


### PR DESCRIPTION
## Summary

Closes #270. Replaces the cutover-time semantic flip in `domains.{frontend,api,docs}` with an explicit two-tier schema, and fixes the config-only-sync gap on the api Deployment.

### Schema rename

- `domains.{frontend,api,docs}` → `domains.legacy.{frontend,api,docs}` (the 301-redirect source post-cutover).
- `domains.webwhen.*` → `domains.live.*` (the customer-facing hostname post-cutover).
- The templates' fallback pattern (`default .Values.domains.legacy.api (dig "live" "api" "" .Values.domains)`) is preserved verbatim — staging still has only the `legacy` block, and `dig` still walks the map looking for `live` before defaulting back. Same semantics, no behaviour change.

### Why

`domains.frontend` etc. flipped meaning at T-0 (#268) — same key was the live host pre-cutover and the redirect source post-cutover. The flip caused the config bug fixed in PR #269 and was a trap for any future contributor. The new names make the intent unmistakable at the consumer site.

### Bonus: `checksum/configmap` annotation on api Deployment

Backend `API_URL` / `FRONTEND_URL` come in via `envFrom` on the ConfigMap. Without a checksum annotation, a config-only Helm sync (same image tag, different ConfigMap) does **not** roll API pods. Frontend's `config.js` is volume-mounted and picks up changes without restart; api was the gap.

### Surfaces touched

- `helm/torale/values{,-production,-staging,-webwhen-soak}.yaml`
- `helm/torale/templates/{configmap,frontend-config,httproute,api-deployment}.yaml`

## Test plan

- [x] `helm template` renders cleanly for prod, staging, soak overlay
- [x] Diff vs main: only comment text + new checksum annotation. Zero hostname / runtime-config drift on prod or staging
- [x] All 7 prod hostnames present (3 legacy redirect + 4 live), API_URL/FRONTEND_URL resolve to the live block
- [ ] Post-merge: smoke webwhen.ai apex/api/docs at T+5min from edge AND origin; verify torale.ai 301s still work. Bump `helmDefaults.timeout` if Autopilot mutator-loop bites instead of retrying.