### PR TITLE
ci(deploy): workflow_dispatch ref + extra_values overlay (#258)

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -9,6 +9,15 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to deploy. Defaults to main.'
+        required: false
+        default: 'main'
+      extra_values:
+        description: 'Optional helm values overlay to layer on top of values-production.yaml (e.g. helm/torale/values-webwhen-soak.yaml). Empty for a normal prod sync.'
+        required: false
+        default: ''
 
 concurrency:
   group: production-deploy
@@ -18,6 +27,11 @@ env:
   GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
   GKE_CLUSTER: clusterkit
   GKE_REGION: us-central1
+  # On push events, inputs.ref is empty so we fall through to github.sha.
+  # On workflow_dispatch, the job's `actions/checkout` step receives inputs.ref
+  # via the `with: ref:` parameter so the build runs against the requested
+  # branch; IMAGE_TAG still tags by github.sha (the resolved commit on that
+  # ref) so the deployed image is addressable in GCR.
   IMAGE_TAG: ${{ github.sha }}
 
 jobs:
@@ -26,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Validate structure
         run: |
@@ -66,6 +82,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -117,6 +135,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -134,6 +154,10 @@ jobs:
         uses: helmfile/helmfile-action@v2.0.5
         env:
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          # Optional helm values overlay (e.g. soak window, hotfix-from-branch).
+          # Empty on push events; set via workflow_dispatch input. Helmfile
+          # honours it via the EXTRA_VALUES env var below in helmfile.yaml.gotmpl.
+          EXTRA_VALUES: ${{ inputs.extra_values }}
         with:
           helmfile-version: v0.162.0
           helm-version: v3.19.0

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -149,6 +149,13 @@ releases:
       component: torale
     values:
       - helm/torale/{{ .Values.valuesFile }}
+      # Optional overlay layered on top of the env's values file. Set via the
+      # EXTRA_VALUES env var (or the workflow_dispatch input that maps to it
+      # in production.yml). Empty string means no overlay — helmfile expands
+      # to nothing and only the base values file applies.
+      {{- if env "EXTRA_VALUES" }}
+      - {{ env "EXTRA_VALUES" }}
+      {{- end }}
     set:
       - name: image.tag
         value: {{ env "IMAGE_TAG" | default "latest" }}


### PR DESCRIPTION
## Summary

Closes #258. Adds two `workflow_dispatch` inputs to `.github/workflows/production.yml` so we can deploy a non-main branch and/or layer an extra helm values file without merging-to-main and without manual local helmfile sync from a peer's worktree.

### Inputs

- `ref` — branch, tag, or SHA. Defaults to `main`. Used for all three `actions/checkout` steps so the build runs against the requested commit.
- `extra_values` — optional helm values overlay path (e.g. `helm/torale/values-webwhen-soak.yaml`). Defaults to empty.

### Wiring

- `helmfile.yaml.gotmpl` reads `EXTRA_VALUES` and conditionally appends it to the torale release's `values:` list. Empty = no overlay, identical to today's render.
- The deploy step exports `EXTRA_VALUES: ${{ inputs.extra_values }}`. On push events, `inputs.extra_values` is empty, so the env var is empty, so the overlay is omitted. **No behaviour change for the normal push-to-main path.**

### Usage

```bash
gh workflow run production.yml \
  -f ref=feat/some-hotfix \
  -f extra_values=helm/torale/values-webwhen-soak.yaml
```

## Test plan

- [x] `EXTRA_VALUES="" helmfile -e production build` renders only `values-production.yaml` (current behaviour preserved on push).
- [x] `EXTRA_VALUES="helm/torale/values-webwhen-soak.yaml" helmfile -e production build` renders both files, overlay layered on top.
- [ ] Manually dispatch with `ref=main` (no overlay) post-merge to confirm the workflow still works for the default path before the next push-to-main re-tests it.