### PR TITLE
chore(helm): group SEO path matches in HTTPRoute rules (#251)

### DIFF
--- a/helm/torale/templates/httproute.yaml
+++ b/helm/torale/templates/httproute.yaml
@@ -45,41 +45,20 @@ spec:
         hostname: {{ .Values.domains.live.frontend | quote }}
         statusCode: 301
   {{- else }}
-  # SEO endpoints served by backend API (must be before frontend catchall)
+  # SEO endpoints served by backend API (must be before frontend catchall).
+  # Grouped into one rule with multiple matches — Gateway API treats each
+  # match independently while sharing backendRefs, which is exactly what
+  # this set wants.
   - matches:
     - path:
         type: Exact
         value: /sitemap.xml
-    backendRefs:
-    - group: ""
-      kind: Service
-      name: {{ $fullName }}-api
-      namespace: {{ $serviceNamespace }}
-      port: {{ .Values.api.service.port }}
-      weight: 1
-  - matches:
     - path:
         type: Exact
         value: /sitemap-dynamic.xml
-    backendRefs:
-    - group: ""
-      kind: Service
-      name: {{ $fullName }}-api
-      namespace: {{ $serviceNamespace }}
-      port: {{ .Values.api.service.port }}
-      weight: 1
-  - matches:
     - path:
         type: Exact
         value: /changelog.xml
-    backendRefs:
-    - group: ""
-      kind: Service
-      name: {{ $fullName }}-api
-      namespace: {{ $serviceNamespace }}
-      port: {{ .Values.api.service.port }}
-      weight: 1
-  - matches:
     - path:
         type: Exact
         value: /robots.txt
@@ -278,64 +257,18 @@ spec:
   hostnames:
   - {{ .Values.domains.live.frontend | quote }}
   rules:
+  # SEO endpoints served by backend API (must be before frontend catchall).
+  # Grouped — same backendRefs and same noindex filter for all four paths.
   - matches:
     - path:
         type: Exact
         value: /sitemap.xml
-    {{- if .Values.httproute.noindex }}
-    filters:
-    - type: ResponseHeaderModifier
-      responseHeaderModifier:
-        set:
-        - name: X-Robots-Tag
-          value: "noindex, nofollow"
-    {{- end }}
-    backendRefs:
-    - group: ""
-      kind: Service
-      name: {{ $fullName }}-api
-      namespace: {{ $serviceNamespace }}
-      port: {{ .Values.api.service.port }}
-      weight: 1
-  - matches:
     - path:
         type: Exact
         value: /sitemap-dynamic.xml
-    {{- if .Values.httproute.noindex }}
-    filters:
-    - type: ResponseHeaderModifier
-      responseHeaderModifier:
-        set:
-        - name: X-Robots-Tag
-          value: "noindex, nofollow"
-    {{- end }}
-    backendRefs:
-    - group: ""
-      kind: Service
-      name: {{ $fullName }}-api
-      namespace: {{ $serviceNamespace }}
-      port: {{ .Values.api.service.port }}
-      weight: 1
-  - matches:
     - path:
         type: Exact
         value: /changelog.xml
-    {{- if .Values.httproute.noindex }}
-    filters:
-    - type: ResponseHeaderModifier
-      responseHeaderModifier:
-        set:
-        - name: X-Robots-Tag
-          value: "noindex, nofollow"
-    {{- end }}
-    backendRefs:
-    - group: ""
-      kind: Service
-      name: {{ $fullName }}-api
-      namespace: {{ $serviceNamespace }}
-      port: {{ .Values.api.service.port }}
-      weight: 1
-  - matches:
     - path:
         type: Exact
         value: /robots.txt


### PR DESCRIPTION
## Summary

Closes #251. Consolidates the 4 separate Gateway API HTTPRoute rules for `/sitemap.xml`, `/sitemap-dynamic.xml`, `/changelog.xml`, `/robots.txt` into a single rule with 4 matches, on both the torale-main and webwhen-main routes. -73 lines, identical routing behaviour.

### Why this is safe

Gateway API's rule-level `filters` and `backendRefs` apply to every match in that rule. The 4 SEO endpoints all share the same backend (`<release>-api`) and, on webwhen-main, the same `X-Robots-Tag` filter — so collapsing them is a pure deduplication. Each path is `Exact`-typed and disjoint from the others, so there's no precedence ambiguity introduced by sharing a rule.

### Diff verification

- Prod render (cutover=true, noindex=false): only changes are the 3 redundant `backendRefs` blocks removed. Same paths matched, same backend, no filter changes.
- Soak render (noindex=true): X-Robots-Tag `noindex, nofollow` still applies to all 4 SEO paths via the rule-level filter. Verified by counting paths inside the SEO rule's `matches:` block.

## Test plan

- [x] `diff` of `helm template` output vs main (prod values): only removed-redundancy delta, no semantic change
- [x] `diff` with `--set httproute.noindex=true`: same shape, X-Robots-Tag still on all 4 SEO paths
- [ ] Post-merge: verify `curl -sSI https://webwhen.ai/sitemap.xml` and `/robots.txt` return 200 from the api backend (not the frontend catchall) at T+5min from edge AND origin