### PR TITLE
chore(staging): parallel routes to staging.webwhen.ai + CI improvements (#281, #293)

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,18 +1,25 @@
 # Staging deployment workflow
-# Deploys to staging.torale.ai for testing before production
+# Deploys to staging.webwhen.ai for testing before production
+# (legacy staging.torale.ai still served in parallel during the #281 soak)
 
 name: Deploy to Staging
 
+# Trigger matrix:
+# - workflow_dispatch: manual deploy from any branch
+# - labeled (with name=deploy): bring staging up for a PR
+# - synchronize (when PR is already labeled deploy): redeploy on every push
+# - closed (when PR was labeled deploy): scale staging namespace to 0
 on:
   workflow_dispatch:
   pull_request:
-    types: [labeled]
+    types: [labeled, synchronize, closed]
 
 jobs:
   build:
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event.action == 'labeled' && github.event.label.name == 'deploy')
+      (github.event.action == 'labeled' && github.event.label.name == 'deploy') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'deploy'))
     name: Build ${{ matrix.component }}
     runs-on: ubuntu-latest
 
@@ -69,7 +76,7 @@ jobs:
           # Stage origin baked into prerendered JSON-LD / RSS / etc. for the
           # frontend image only. Other components ignore the arg.
           build-args: |
-            PRERENDER_ORIGIN=https://staging.torale.ai
+            PRERENDER_ORIGIN=https://staging.webwhen.ai
           tags: |
             gcr.io/${{ env.GCP_PROJECT_ID }}/torale-${{ matrix.component }}:${{ env.IMAGE_TAG }}
             gcr.io/${{ env.GCP_PROJECT_ID }}/torale-${{ matrix.component }}:staging
@@ -90,7 +97,7 @@ jobs:
 
     environment:
       name: staging
-      url: https://staging.torale.ai
+      url: https://staging.webwhen.ai
 
     env:
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
@@ -130,6 +137,20 @@ jobs:
           kubectl rollout status deployment/torale-agent-free -n torale-staging --timeout=5m
           kubectl rollout status deployment/torale-agent-paid -n torale-staging --timeout=5m
 
+      # Smoke from edge mirrors production.yml. Catches DNS-not-yet-propagated
+      # cases earlier than waiting for the PR comment to fire. Both new and
+      # legacy hostnames are checked during the soak window; once the legacy
+      # block is retired (PR 2 of #281), the legacy curls will be removed.
+      - name: Smoke staging
+        run: |
+          set -e
+          echo "=== EDGE: staging.webwhen.ai (live) ==="
+          curl -sSI --retry 3 --retry-delay 5 https://staging.webwhen.ai/ | head -3
+          echo "=== EDGE: api-staging.webwhen.ai (live) ==="
+          curl -sSI --retry 3 --retry-delay 5 https://api-staging.webwhen.ai/health | head -3
+          echo "=== EDGE: staging.torale.ai (legacy, parallel route during soak) ==="
+          curl -sSI --retry 3 --retry-delay 5 https://staging.torale.ai/ | head -3 || echo "  legacy unreachable — expected once PR 2 retires it"
+
       - name: Post Deployment Info
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
@@ -139,5 +160,48 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🚀 **Deployed to Staging!**\n\n- **URL**: https://staging.torale.ai\n- **API**: https://api-staging.torale.ai\n- **Commit**: \`${{ github.sha }}\``
+              body: `🚀 **Deployed to Staging!**\n\n- **URL**: https://staging.webwhen.ai\n- **API**: https://api-staging.webwhen.ai\n- **Commit**: \`${{ github.sha }}\``
             })
+
+  scale_down:
+    # Scale the shared torale-staging namespace to 0 when a labeled PR closes
+    # (merged OR unmerged — both paths free up cluster capacity). Per #293.
+    #
+    # Note: scaling the SHARED torale-staging namespace to 0 on PR close kills
+    # any other concurrently-labeled PR's environment. Acceptable today
+    # (single-PR staging usage in practice); revisit if multi-PR concurrent
+    # staging becomes a thing — would need either per-PR namespaces or a
+    # liveness check ("are any other PRs still labeled deploy?") before scaling.
+    name: Scale staging to zero on PR close
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      contains(github.event.pull_request.labels.*.name, 'deploy')
+
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      GKE_CLUSTER: clusterkit
+      GKE_REGION: us-central1
+
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ env.GKE_CLUSTER }}
+          location: ${{ env.GKE_REGION }}
+
+      - name: Scale all deployments in torale-staging to 0
+        run: |
+          kubectl scale deployment -n torale-staging --replicas=0 --all
+          kubectl get deployment -n torale-staging

--- a/helm/torale/values-staging.yaml
+++ b/helm/torale/values-staging.yaml
@@ -1,13 +1,20 @@
 # Staging values for Torale on GKE ClusterKit
-# Deployed to staging.torale.ai for pre-production testing
+# Deployed to staging.webwhen.ai (cutover-in-progress; legacy staging.torale.ai
+# routes still render in parallel during the soak window of #281)
 
 domains:
-  # Staging has no parallel webwhen routes; legacy IS the live hostname.
-  # See #270 for the schema rationale.
   legacy:
+    # Soak-window keep-alive. Both routes render in parallel; verify the
+    # webwhen.ai routes are healthy before retiring this block in PR 2.
     frontend: staging.torale.ai
     api: api-staging.torale.ai
     docs: docs-staging.torale.ai
+  live:
+    # Customer-facing post-#281. Wildcard *.webwhen.ai cert
+    # (webwhen-ai-origin-cert, attached to clusterkit-gateway via pre-shared
+    # annotation) covers both hostnames already; no per-host cert needed.
+    frontend: staging.webwhen.ai
+    api: api-staging.webwhen.ai
 
 # Clerk authentication (uses production Clerk app - same as production)
 # Rotated 2026-05-03 alongside production for the webwhen.ai rebrand cutover.
@@ -66,5 +73,13 @@ docs:
 # Keep staging out of search indices. Backend's /robots.txt already serves
 # `Disallow: /` but X-Robots-Tag covers crawlers that ignore robots.txt.
 # Closes #280.
+#
+# Two flags, two scopes:
+# - stagingNoindex: applies to the legacy staging.torale.ai frontend catchall
+#   only (a $isStagingRelease-gated branch in httproute.yaml).
+# - noindex: applies to every webwhen-* route (the rebrand soak overlay's
+#   primary safety mechanism). Set true on staging because staging.webwhen.ai
+#   is also a non-production domain that should never be indexed.
 httproute:
   stagingNoindex: true
+  noindex: true

--- a/helmfile.yaml.gotmpl
+++ b/helmfile.yaml.gotmpl
@@ -22,7 +22,7 @@ environments:
   staging:
     values:
       - namespace: torale-staging
-        domain: staging.torale.ai
+        domain: staging.webwhen.ai
         valuesFile: values-staging.yaml
         taskQueue: torale-staging
 


### PR DESCRIPTION
## Summary

Closes #281 (PR 1 of 2) and #293. Stands up parallel `staging.webwhen.ai` HTTPRoutes alongside the legacy `staging.torale.ai` routes for soak verification, then a follow-up PR 2 retires the legacy block. Also bundles three staging-CI improvements that touch the same surface.

### Part A — #281: parallel routes (PR 1 of 2)

- `helm/torale/values-staging.yaml` adds `domains.live.{frontend,api}` for `staging.webwhen.ai` / `api-staging.webwhen.ai`. Both legacy and live routes render in parallel.
- Sets `httproute.noindex: true` (staging side) so the new webwhen-* routes inherit X-Robots-Tag noindex via the existing soak overlay filter logic. Belt-and-suspenders alongside the existing `stagingNoindex` flag on the legacy frontend catchall.
- `helmfile.yaml.gotmpl` updates the staging environment's informational `domain:` value to `staging.webwhen.ai`.
- **No new cert.** `webwhen-ai-origin-cert` (Cloudflare Origin CA wildcard `*.webwhen.ai`) is already attached to `clusterkit-gateway` and covers both new hostnames.
- **No template changes.** The webwhen-* HTTPRoutes (gated on `if .Values.domains.live`, post-#270) light up automatically once the `live` block is present in staging values. ExternalDNS upserts the records on apply.

### Part B — #293: three CI improvements

All three touch `.github/workflows/staging.yml`:

1. **Migrations on push (label-bearing PRs)** — implicit in #2 below: pushes redeploy the chart, the chart's migration-job Helm hook runs alembic before app rollout. No new code, just a side-effect of #2.
2. **Auto-redeploy on commit while `deploy` label is present** — adds `synchronize` to `pull_request.types` and gates the build job on `(action == synchronize && contains(pull_request.labels.*.name, 'deploy'))`.
3. **Scale staging namespace to zero on PR close** — new `scale_down` job triggered on `pull_request.types: [closed]`. Per the issue's explicit instruction, no `merged == true` filter — both merged and unmerged closes scale down. Gated on the PR having had the `deploy` label (`contains(pull_request.labels.*.name, 'deploy')`).

> **Concurrent-PR scale-down race**: scaling the shared `torale-staging` namespace to 0 on PR close kills any other concurrently-labeled PR's environment. Acceptable today (single-PR staging usage in practice). Documented as a code comment near the scale-down job; revisit if multi-PR concurrent staging becomes a thing — would need either per-PR namespaces or a liveness check before scaling.

### Bonus: smoke step

Mirrors `production.yml` pattern. Curls `staging.webwhen.ai`, `api-staging.webwhen.ai/health`, and (during soak) `staging.torale.ai`. Catches DNS-not-yet-propagated cases earlier than waiting for the PR comment to fire.

### Bonus: post-deploy URLs flip

PR comment + environment URL flip from `staging.torale.ai` to `staging.webwhen.ai`. The frontend image's `PRERENDER_ORIGIN` build-arg also flips, so the prerendered JSON-LD and RSS bake the right origin.

## Test plan

- [x] `helm template torale-staging helm/torale -f values-staging.yaml --namespace torale-staging` renders all 4 hostnames in parallel: staging.torale.ai, api-staging.torale.ai, staging.webwhen.ai, api-staging.webwhen.ai
- [x] `API_URL`/`FRONTEND_URL` ConfigMap entries resolve to `https://api-staging.webwhen.ai`/`https://staging.webwhen.ai` via the dig fallback (live takes precedence over legacy when present, per #270)
- [x] X-Robots-Tag noindex applied to all webwhen-* rules + legacy frontend catchall
- [x] YAML lint clean on `.github/workflows/staging.yml`
- [ ] **Post-merge**: smoke `staging.webwhen.ai` + `api-staging.webwhen.ai` from edge AND origin at T+5min. Verify both hostnames carry `X-Robots-Tag: noindex, nofollow`. Verify legacy `staging.torale.ai` still serves (parallel during soak).
- [ ] **PR 2 follow-up**: once smoke is clean, open a small PR removing the `domains.legacy` block from values-staging.yaml. Retires the legacy routes. No 301 (no SEO equity on staging, no external bookmarks worth preserving).
- [ ] **CI smoke** for #293: when this PR lands, manually push a commit to a `deploy`-labeled PR to verify auto-redeploy. Manually close such a PR (without merging) to verify scale-down fires.

## Coordination

Heads-up to `torale.seo-audit-claude-code` (#294 audit train): this PR doesn't touch any of the source files in their fix list. Helm changes mean staging `FRONTEND_URL`/`API_URL` env vars auto-flip to webwhen.ai post-merge — no code change needed on their side for that particular item.