### PR TITLE
fix(seo): allow webwhen.ai through prod robots.txt gate

### DIFF
--- a/backend/src/torale/api/routers/sitemap.py
+++ b/backend/src/torale/api/routers/sitemap.py
@@ -217,6 +217,9 @@ async def generate_changelog_rss():
     return Response(content=xml_output, media_type="application/rss+xml")
 
 
+PROD_FRONTEND_URLS = frozenset({"https://webwhen.ai", "https://torale.ai"})
+
+
 @router.get("/robots.txt")
 async def robots_txt():
     """
@@ -225,7 +228,7 @@ async def robots_txt():
     """
     base_url = settings.frontend_url
 
-    if base_url != "https://torale.ai":
+    if base_url not in PROD_FRONTEND_URLS:
         return Response(content="User-agent: *\nDisallow: /\n", media_type="text/plain")
 
     robots = f"""User-agent: *


### PR DESCRIPTION
## Summary

`backend/src/torale/api/routers/sitemap.py:228` hardcoded `https://torale.ai` as the production sentinel. After the rebrand, `settings.frontend_url` is `https://webwhen.ai`, so prod fell through to the staging-style blanket `Disallow: /`. Search crawlers have been locked out of webwhen.ai since cutover.

```
$ curl https://webwhen.ai/robots.txt
User-agent: *
Disallow: /
```

This single line is blocking GSC submission. P0 from the audit (#294, [findings comment](https://github.com/prassanna-ravishankar/torale/issues/294#issuecomment-4383169058)).

## Change

Gate against a frozenset of known prod origins so both `webwhen.ai` (the live host) and `torale.ai` (still in service as the 301-redirect source — backend may serve robots.txt to torale.ai requests if any bypass the edge redirect) are treated as production.

Scoped intentionally tight: robots-only. RSS channel branding, config default, and the broader brand sweep are deferred to follow-up PRs (#294 PR plan).

## Test plan

- [ ] CI green
- [ ] Post-deploy: `curl https://webwhen.ai/robots.txt` returns the production allow/disallow stanza with the webwhen sitemap URL
- [ ] Post-deploy: `curl https://staging.torale.ai/robots.txt` (and any staging.webwhen.ai once live) still returns blanket `Disallow: /`

Refs #294