### PR TITLE
fix(seo): bake canonical + og:url into prerendered HTML

### DIFF
--- a/backend/src/torale/api/routers/sitemap.py
+++ b/backend/src/torale/api/routers/sitemap.py
@@ -217,6 +217,9 @@ async def generate_changelog_rss():
     return Response(content=xml_output, media_type="application/rss+xml")
 
 
+PROD_FRONTEND_URLS = frozenset({"https://webwhen.ai", "https://torale.ai"})
+
+
 @router.get("/robots.txt")
 async def robots_txt():
     """
@@ -225,7 +228,7 @@ async def robots_txt():
     """
     base_url = settings.frontend_url
 
-    if base_url != "https://torale.ai":
+    if base_url not in PROD_FRONTEND_URLS:
         return Response(content="User-agent: *\nDisallow: /\n", media_type="text/plain")
 
     robots = f"""User-agent: *

--- a/frontend/src/components/DynamicMeta.tsx
+++ b/frontend/src/components/DynamicMeta.tsx
@@ -1,37 +1,24 @@
 import { Helmet } from 'react-helmet-async';
+import { getOrigin } from '@/utils/origin';
 
 /**
  * Self-canonical origin: emit URLs that match the document's own origin so
- * pages served from webwhen.ai declare webwhen.ai canonical, and pages served
- * from torale.ai declare torale.ai canonical. Replaces a hardcoded
- * `https://torale.ai` literal that polluted webwhen.ai pages with torale.ai
- * canonical/og:url after react-helmet hydration. Found via the soak smoke;
- * see #246.
- *
- * During prerender (`scripts/prerender.mjs` running headless against
- * `http://localhost:4567`), `window.location.origin` is the local server,
- * not the production domain. Skip the URL-shaped tags during prerender so
- * the static `<head>` in `index.html` (already correctly webwhen.ai-shaped)
- * survives into the baked HTML. At real runtime hydration on production,
- * react-helmet adds the runtime tags with the correct origin.
+ * pages served from webwhen.ai declare webwhen.ai canonical (#246). Uses the
+ * shared `getOrigin()` helper, which reads `window.__PRERENDER_ORIGIN__`
+ * during prerender (defaults to https://webwhen.ai, overridden via the
+ * PRERENDER_ORIGIN env for staging/preview builds). Without this prerender
+ * fallback, JS-less crawlers (Bing, Yandex, social card scrapers) saw the
+ * baked HTML with no canonical at all. See #294.
  */
-const isPrerender =
-  typeof window !== 'undefined' && (window as unknown as { __PRERENDER__?: boolean }).__PRERENDER__;
-
-function getOrigin(): string | null {
-  if (typeof window === 'undefined') return null;
-  if (isPrerender) return null;
-  return window.location.origin;
-}
 
 const FALLBACK_IMAGE = '/og-image.webp';
 
 interface DynamicMetaProps {
   /**
    * Path from site root (e.g. "/compare/visualping-alternative"). Used to
-   * build canonical, og:url and twitter:url at runtime against the document
-   * origin. Provide this for every public page; `url` is the escape hatch
-   * for explicit non-self canonicals (rare).
+   * build canonical, og:url and twitter:url against the resolved origin.
+   * Provide this for every public page; `url` is the escape hatch for
+   * explicit non-self canonicals (rare).
    */
   path?: string;
   url?: string;
@@ -50,8 +37,8 @@ export function DynamicMeta({
   type = 'website',
 }: DynamicMetaProps) {
   const origin = getOrigin();
-  const resolvedUrl = url ?? (origin ? `${origin}${path ?? '/'}` : null);
-  const resolvedImage = image ?? (origin ? `${origin}${FALLBACK_IMAGE}` : null);
+  const resolvedUrl = url ?? `${origin}${path ?? '/'}`;
+  const resolvedImage = image ?? `${origin}${FALLBACK_IMAGE}`;
 
   return (
     <Helmet>
@@ -59,18 +46,18 @@ export function DynamicMeta({
       <meta name="description" content={description} />
 
       <meta property="og:type" content={type} />
-      {resolvedUrl && <meta property="og:url" content={resolvedUrl} />}
+      <meta property="og:url" content={resolvedUrl} />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
-      {resolvedImage && <meta property="og:image" content={resolvedImage} />}
+      <meta property="og:image" content={resolvedImage} />
 
       <meta name="twitter:card" content="summary_large_image" />
-      {resolvedUrl && <meta name="twitter:url" content={resolvedUrl} />}
+      <meta name="twitter:url" content={resolvedUrl} />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
-      {resolvedImage && <meta name="twitter:image" content={resolvedImage} />}
+      <meta name="twitter:image" content={resolvedImage} />
 
-      {resolvedUrl && <link rel="canonical" href={resolvedUrl} />}
+      <link rel="canonical" href={resolvedUrl} />
     </Helmet>
   );
 }


### PR DESCRIPTION
## Summary

`DynamicMeta` returned `null` for origin during prerender, so `<link rel=\"canonical\">`, `og:url`, `og:image`, `twitter:url`, and `twitter:image` were all skipped from the baked HTML. JS-less crawlers (Bing, Yandex, Facebook/Twitter card scrapers, Slackbot) saw **zero** canonical signal on every public page.

```
$ curl -s https://webwhen.ai/ | grep -c 'rel=\"canonical\"'
0
```

P0 from the audit (#294, [findings comment](https://github.com/prassanna-ravishankar/torale/issues/294#issuecomment-4383169058)).

## Change

The prerender script (`scripts/prerender.mjs:64`) already injects `window.__PRERENDER_ORIGIN__` (defaults to `https://webwhen.ai`, override-able via the `PRERENDER_ORIGIN` env for staging/preview builds). The shared `utils/origin.ts` helper already consumes that variable for JSON-LD (#282). `DynamicMeta` was the odd one out, doing its own incomplete origin detection.

Switch `DynamicMeta` to the shared `getOrigin()` helper so canonical/og/twitter URLs use the prod origin during prerender too. Drops a chunk of duplicated origin logic and several null-guards in the JSX.

## Test plan

- [x] `npm run build` succeeds; prerender postcondition passes
- [x] Every baked route now ships a correct canonical:
  ```
  $ grep -oE 'canonical\" href=\"[^\"]+\"' dist/*.html dist/**/*.html
  dist/index.html:                        canonical\" href=\"https://webwhen.ai/\"
  dist/changelog.html:                    canonical\" href=\"https://webwhen.ai/changelog\"
  dist/explore.html:                      canonical\" href=\"https://webwhen.ai/explore\"
  dist/use-cases/steam-game-price-alerts.html: canonical\" href=\"https://webwhen.ai/use-cases/steam-game-price-alerts\"
  dist/compare/visualping-alternative.html: canonical\" href=\"https://webwhen.ai/compare/visualping-alternative\"
  dist/concepts/self-scheduling-agents.html: canonical\" href=\"https://webwhen.ai/concepts/self-scheduling-agents\"
  dist/privacy.html:                      canonical\" href=\"https://webwhen.ai/privacy\"
  ...
  ```
- [x] `tsc --noEmit` clean
- [x] eslint clean
- [x] Spot-checked: pre-existing React #418/#423 hydration warnings on `/use-cases/*` and `/concepts/*` reproduce on `main` — not introduced here
- [ ] CI green
- [ ] Post-deploy: `curl https://webwhen.ai/ | grep canonical` returns the canonical tag

Refs #294