### PR TITLE
fix(seo): docs canonicals + sitemap on docs.webwhen.ai

### DIFF
--- a/backend/src/torale/api/routers/sitemap.py
+++ b/backend/src/torale/api/routers/sitemap.py
@@ -217,6 +217,9 @@ async def generate_changelog_rss():
     return Response(content=xml_output, media_type="application/rss+xml")
 
 
+PROD_FRONTEND_URLS = frozenset({"https://webwhen.ai", "https://torale.ai"})
+
+
 @router.get("/robots.txt")
 async def robots_txt():
     """
@@ -225,7 +228,7 @@ async def robots_txt():
     """
     base_url = settings.frontend_url
 
-    if base_url != "https://torale.ai":
+    if base_url not in PROD_FRONTEND_URLS:
         return Response(content="User-agent: *\nDisallow: /\n", media_type="text/plain")
 
     robots = f"""User-agent: *

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -1,9 +1,11 @@
 import { defineConfig, type PageData } from 'vitepress'
 import { withMermaid } from 'vitepress-plugin-mermaid'
 
-// SITE_ORIGIN stays on docs.torale.ai for now. Clusterkit's HTTPRoutes flip the
-// hostname at the gateway during cutover; the build doesn't hardcode webwhen.ai.
-const SITE_ORIGIN = 'https://docs.torale.ai'
+// docs.torale.ai 301s to docs.webwhen.ai post-cutover. Bake webwhen.ai into
+// canonicals + sitemap so the live origin owns the index signal. Otherwise
+// pages declare "I am a duplicate of docs.torale.ai" while docs.torale.ai
+// redirects back here — a canonical/redirect loop. See #294.
+const SITE_ORIGIN = 'https://docs.webwhen.ai'
 const SITE_DESCRIPTION = 'webwhen developer documentation — REST API and Python SDK for the agent that watches the open web.'
 
 export default withMermaid(
@@ -86,8 +88,7 @@ export default withMermaid(
       { text: 'Architecture', link: '/architecture/self-scheduling-agents', activeMatch: '/architecture/' },
       { text: 'API', link: '/api/overview', activeMatch: '/api/' },
       { text: 'SDK', link: '/sdk/quickstart', activeMatch: '/sdk/' },
-      // App URL flips to webwhen.ai at cutover (gateway-level).
-      { text: 'App', link: 'https://torale.ai' }
+      { text: 'App', link: 'https://webwhen.ai' }
     ],
 
     sidebar: {

--- a/docs-site/.vitepress/redirects.ts
+++ b/docs-site/.vitepress/redirects.ts
@@ -1,5 +1,5 @@
 /**
- * Source of truth for docs.torale.ai redirects. The generated
+ * Source of truth for docs.webwhen.ai redirects. The generated
  * nginx-redirects.conf is derived from this — edit here, never the conf.
  * Use 301 for deprecated pages with a sensible replacement, 410 for
  * intentionally-removed pages with no equivalent.

--- a/frontend/src/components/DynamicMeta.tsx
+++ b/frontend/src/components/DynamicMeta.tsx
@@ -1,37 +1,24 @@
 import { Helmet } from 'react-helmet-async';
+import { getOrigin } from '@/utils/origin';
 
 /**
  * Self-canonical origin: emit URLs that match the document's own origin so
- * pages served from webwhen.ai declare webwhen.ai canonical, and pages served
- * from torale.ai declare torale.ai canonical. Replaces a hardcoded
- * `https://torale.ai` literal that polluted webwhen.ai pages with torale.ai
- * canonical/og:url after react-helmet hydration. Found via the soak smoke;
- * see #246.
- *
- * During prerender (`scripts/prerender.mjs` running headless against
- * `http://localhost:4567`), `window.location.origin` is the local server,
- * not the production domain. Skip the URL-shaped tags during prerender so
- * the static `<head>` in `index.html` (already correctly webwhen.ai-shaped)
- * survives into the baked HTML. At real runtime hydration on production,
- * react-helmet adds the runtime tags with the correct origin.
+ * pages served from webwhen.ai declare webwhen.ai canonical (#246). Uses the
+ * shared `getOrigin()` helper, which reads `window.__PRERENDER_ORIGIN__`
+ * during prerender (defaults to https://webwhen.ai, overridden via the
+ * PRERENDER_ORIGIN env for staging/preview builds). Without this prerender
+ * fallback, JS-less crawlers (Bing, Yandex, social card scrapers) saw the
+ * baked HTML with no canonical at all. See #294.
  */
-const isPrerender =
-  typeof window !== 'undefined' && (window as unknown as { __PRERENDER__?: boolean }).__PRERENDER__;
-
-function getOrigin(): string | null {
-  if (typeof window === 'undefined') return null;
-  if (isPrerender) return null;
-  return window.location.origin;
-}
 
 const FALLBACK_IMAGE = '/og-image.webp';
 
 interface DynamicMetaProps {
   /**
    * Path from site root (e.g. "/compare/visualping-alternative"). Used to
-   * build canonical, og:url and twitter:url at runtime against the document
-   * origin. Provide this for every public page; `url` is the escape hatch
-   * for explicit non-self canonicals (rare).
+   * build canonical, og:url and twitter:url against the resolved origin.
+   * Provide this for every public page; `url` is the escape hatch for
+   * explicit non-self canonicals (rare).
    */
   path?: string;
   url?: string;
@@ -50,8 +37,8 @@ export function DynamicMeta({
   type = 'website',
 }: DynamicMetaProps) {
   const origin = getOrigin();
-  const resolvedUrl = url ?? (origin ? `${origin}${path ?? '/'}` : null);
-  const resolvedImage = image ?? (origin ? `${origin}${FALLBACK_IMAGE}` : null);
+  const resolvedUrl = url ?? `${origin}${path ?? '/'}`;
+  const resolvedImage = image ?? `${origin}${FALLBACK_IMAGE}`;
 
   return (
     <Helmet>
@@ -59,18 +46,18 @@ export function DynamicMeta({
       <meta name="description" content={description} />
 
       <meta property="og:type" content={type} />
-      {resolvedUrl && <meta property="og:url" content={resolvedUrl} />}
+      <meta property="og:url" content={resolvedUrl} />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
-      {resolvedImage && <meta property="og:image" content={resolvedImage} />}
+      <meta property="og:image" content={resolvedImage} />
 
       <meta name="twitter:card" content="summary_large_image" />
-      {resolvedUrl && <meta name="twitter:url" content={resolvedUrl} />}
+      <meta name="twitter:url" content={resolvedUrl} />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
-      {resolvedImage && <meta name="twitter:image" content={resolvedImage} />}
+      <meta name="twitter:image" content={resolvedImage} />
 
-      {resolvedUrl && <link rel="canonical" href={resolvedUrl} />}
+      <link rel="canonical" href={resolvedUrl} />
     </Helmet>
   );
 }


### PR DESCRIPTION
## Summary

`docs.torale.ai` 301s to `docs.webwhen.ai` post-cutover, but VitePress still hardcoded `docs.torale.ai` as `SITE_ORIGIN`. Result:

- Every docs page declared `<link rel="canonical" href="https://docs.torale.ai/...">`
- The sitemap at `https://docs.webwhen.ai/sitemap.xml` listed 23 URLs, all on `docs.torale.ai`
- `https://docs.webwhen.ai/robots.txt` referenced `Sitemap: https://docs.torale.ai/sitemap.xml`

Combined with the legacy 301, that's a canonical/redirect loop — docs declare "I am a duplicate of docs.torale.ai" while docs.torale.ai redirects back here. Effectively unindexable.

P0 from the audit (#294, [findings comment](https://github.com/prassanna-ravishankar/torale/issues/294#issuecomment-4383169058)).

## Change

- Flip `SITE_ORIGIN` to `https://docs.webwhen.ai` in `docs-site/.vitepress/config.ts`. Sitemap and per-page canonical/og:url/twitter:url all flow off this constant.
- Flip the App nav link from `https://torale.ai` to `https://webwhen.ai` (it was a 301 internal link, low-cost to fix while in here). Drop the stale "flips at cutover" comment.
- Update the docs-site `redirects.ts` source-of-truth comment header to say `docs.webwhen.ai`.

## Test plan

- [x] `npm run docs:build` succeeds
- [x] `dist/sitemap.xml` lists all 23 entries on `docs.webwhen.ai`
- [x] `dist/index.html` (and other docs pages) ship `<link rel="canonical" href="https://docs.webwhen.ai/...">`
- [x] `nginx-redirects.conf` regenerated cleanly (7 exact + 4 prefix rules unchanged)
- [ ] CI green
- [ ] Post-deploy: `curl https://docs.webwhen.ai/sitemap.xml | grep -c docs.torale.ai` returns 0
- [ ] Post-deploy: `curl https://docs.webwhen.ai/ | grep canonical` shows `docs.webwhen.ai`

Refs #294