### PR TITLE
chore(brand): sweep stray torale.ai references on public surfaces

### DIFF
--- a/backend/src/torale/api/routers/sitemap.py
+++ b/backend/src/torale/api/routers/sitemap.py
@@ -171,11 +171,10 @@ async def generate_changelog_rss():
     rss.set("xmlns:atom", "http://www.w3.org/2005/Atom")
 
     channel = ET.SubElement(rss, "channel")
-    ET.SubElement(channel, "title").text = "Torale Changelog"
+    ET.SubElement(channel, "title").text = "webwhen changelog"
     ET.SubElement(channel, "link").text = f"{base_url}/changelog"
     ET.SubElement(channel, "description").text = (
-        "Latest updates, features, and improvements to Torale - "
-        "the AI-powered grounded search monitoring platform"
+        "Updates to webwhen — the agent that waits for the web."
     )
     ET.SubElement(channel, "language").text = "en-us"
 

--- a/backend/src/torale/api/routers/sitemap.py
+++ b/backend/src/torale/api/routers/sitemap.py
@@ -173,9 +173,9 @@ async def generate_changelog_rss():
     channel = ET.SubElement(rss, "channel")
     ET.SubElement(channel, "title").text = "webwhen changelog"
     ET.SubElement(channel, "link").text = f"{base_url}/changelog"
-    ET.SubElement(channel, "description").text = (
-        "Updates to webwhen — the agent that waits for the web."
-    )
+    ET.SubElement(
+        channel, "description"
+    ).text = "Updates to webwhen — the agent that waits for the web."
     ET.SubElement(channel, "language").text = "en-us"
 
     # Add atom:link for feed autodiscovery

--- a/backend/src/torale/api/routers/sitemap.py
+++ b/backend/src/torale/api/routers/sitemap.py
@@ -217,6 +217,9 @@ async def generate_changelog_rss():
     return Response(content=xml_output, media_type="application/rss+xml")
 
 
+PROD_FRONTEND_URLS = frozenset({"https://webwhen.ai", "https://torale.ai"})
+
+
 @router.get("/robots.txt")
 async def robots_txt():
     """
@@ -225,7 +228,7 @@ async def robots_txt():
     """
     base_url = settings.frontend_url
 
-    if base_url != "https://torale.ai":
+    if base_url not in PROD_FRONTEND_URLS:
         return Response(content="User-agent: *\nDisallow: /\n", media_type="text/plain")
 
     robots = f"""User-agent: *

--- a/backend/src/torale/core/config.py
+++ b/backend/src/torale/core/config.py
@@ -47,7 +47,7 @@ class Settings(BaseSettings):
     api_reload: bool = False
 
     # Frontend URL for SEO (sitemap, OpenGraph, etc.)
-    frontend_url: str = "https://torale.ai"
+    frontend_url: str = "https://webwhen.ai"
 
     # Public API URL — used to build callback URLs for third-party redirects
     # (e.g. Composio OAuth callbacks). Populated from the API_URL env var in

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -1,9 +1,11 @@
 import { defineConfig, type PageData } from 'vitepress'
 import { withMermaid } from 'vitepress-plugin-mermaid'
 
-// SITE_ORIGIN stays on docs.torale.ai for now. Clusterkit's HTTPRoutes flip the
-// hostname at the gateway during cutover; the build doesn't hardcode webwhen.ai.
-const SITE_ORIGIN = 'https://docs.torale.ai'
+// docs.torale.ai 301s to docs.webwhen.ai post-cutover. Bake webwhen.ai into
+// canonicals + sitemap so the live origin owns the index signal. Otherwise
+// pages declare "I am a duplicate of docs.torale.ai" while docs.torale.ai
+// redirects back here — a canonical/redirect loop. See #294.
+const SITE_ORIGIN = 'https://docs.webwhen.ai'
 const SITE_DESCRIPTION = 'webwhen developer documentation — REST API and Python SDK for the agent that watches the open web.'
 
 export default withMermaid(
@@ -86,8 +88,7 @@ export default withMermaid(
       { text: 'Architecture', link: '/architecture/self-scheduling-agents', activeMatch: '/architecture/' },
       { text: 'API', link: '/api/overview', activeMatch: '/api/' },
       { text: 'SDK', link: '/sdk/quickstart', activeMatch: '/sdk/' },
-      // App URL flips to webwhen.ai at cutover (gateway-level).
-      { text: 'App', link: 'https://torale.ai' }
+      { text: 'App', link: 'https://webwhen.ai' }
     ],
 
     sidebar: {

--- a/docs-site/.vitepress/redirects.ts
+++ b/docs-site/.vitepress/redirects.ts
@@ -1,5 +1,5 @@
 /**
- * Source of truth for docs.torale.ai redirects. The generated
+ * Source of truth for docs.webwhen.ai redirects. The generated
  * nginx-redirects.conf is derived from this — edit here, never the conf.
  * Use 301 for deprecated pages with a sensible replacement, 410 for
  * intentionally-removed pages with no equivalent.

--- a/docs-site/architecture/self-scheduling-agents.md
+++ b/docs-site/architecture/self-scheduling-agents.md
@@ -7,7 +7,7 @@ description: How the agent service, APScheduler, and grounded search compose int
 
 A webwhen watch runs as a self-scheduling agent: each execution decides whether the condition is met _and_ when to run next. This page documents the runtime.
 
-The public-facing explainer lives at [torale.ai/concepts/self-scheduling-agents](https://torale.ai/concepts/self-scheduling-agents). This doc is the engineering view.
+The public-facing explainer lives at [webwhen.ai/concepts/self-scheduling-agents](https://webwhen.ai/concepts/self-scheduling-agents). This doc is the engineering view.
 
 ::: tip Naming during the transition
 The codebase still uses `torale-agent` as the service name and the database table is still called `tasks`. The product is now webwhen; the rename of internal modules and endpoints is a later phase.

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -30,7 +30,7 @@ You (via chat) → OpenClaw → webwhen API (create watch)
 
 ### 1. Get a webwhen API key
 
-Sign up at [torale.ai](https://torale.ai) and create an API key in Settings.
+Sign up at [webwhen.ai](https://webwhen.ai) and create an API key in Settings.
 
 ### 2. Install the skill
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,9 +14,8 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="https://webwhen.ai/og-image.webp">
 
-    <!-- Warm up TLS to the API so Landing fetches are not gated on DNS+TLS.
-         Pre-cutover this still resolves via api.torale.ai; flips at cutover. -->
-    <link rel="preconnect" href="https://api.torale.ai" crossorigin>
+    <!-- Warm up TLS to the API so Landing fetches are not gated on DNS+TLS. -->
+    <link rel="preconnect" href="https://api.webwhen.ai" crossorigin>
 
     <!-- Load runtime config (deferred for better performance) -->
     <script src="/config.js" defer></script>

--- a/frontend/public/.well-known/security.txt
+++ b/frontend/public/.well-known/security.txt
@@ -1,8 +1,8 @@
-Contact: mailto:security@torale.ai
+Contact: mailto:security@webwhen.ai
 Expires: 2026-12-31T23:59:59.000Z
 Preferred-Languages: en
-Canonical: https://torale.ai/.well-known/security.txt
+Canonical: https://webwhen.ai/.well-known/security.txt
 
 # Security Disclosure
-# Please report security vulnerabilities to security@torale.ai
+# Please report security vulnerabilities to security@webwhen.ai
 # We appreciate responsible disclosure and will respond promptly.

--- a/frontend/src/components/DynamicMeta.tsx
+++ b/frontend/src/components/DynamicMeta.tsx
@@ -1,37 +1,24 @@
 import { Helmet } from 'react-helmet-async';
+import { getOrigin } from '@/utils/origin';
 
 /**
  * Self-canonical origin: emit URLs that match the document's own origin so
- * pages served from webwhen.ai declare webwhen.ai canonical, and pages served
- * from torale.ai declare torale.ai canonical. Replaces a hardcoded
- * `https://torale.ai` literal that polluted webwhen.ai pages with torale.ai
- * canonical/og:url after react-helmet hydration. Found via the soak smoke;
- * see #246.
- *
- * During prerender (`scripts/prerender.mjs` running headless against
- * `http://localhost:4567`), `window.location.origin` is the local server,
- * not the production domain. Skip the URL-shaped tags during prerender so
- * the static `<head>` in `index.html` (already correctly webwhen.ai-shaped)
- * survives into the baked HTML. At real runtime hydration on production,
- * react-helmet adds the runtime tags with the correct origin.
+ * pages served from webwhen.ai declare webwhen.ai canonical (#246). Uses the
+ * shared `getOrigin()` helper, which reads `window.__PRERENDER_ORIGIN__`
+ * during prerender (defaults to https://webwhen.ai, overridden via the
+ * PRERENDER_ORIGIN env for staging/preview builds). Without this prerender
+ * fallback, JS-less crawlers (Bing, Yandex, social card scrapers) saw the
+ * baked HTML with no canonical at all. See #294.
  */
-const isPrerender =
-  typeof window !== 'undefined' && (window as unknown as { __PRERENDER__?: boolean }).__PRERENDER__;
-
-function getOrigin(): string | null {
-  if (typeof window === 'undefined') return null;
-  if (isPrerender) return null;
-  return window.location.origin;
-}
 
 const FALLBACK_IMAGE = '/og-image.webp';
 
 interface DynamicMetaProps {
   /**
    * Path from site root (e.g. "/compare/visualping-alternative"). Used to
-   * build canonical, og:url and twitter:url at runtime against the document
-   * origin. Provide this for every public page; `url` is the escape hatch
-   * for explicit non-self canonicals (rare).
+   * build canonical, og:url and twitter:url against the resolved origin.
+   * Provide this for every public page; `url` is the escape hatch for
+   * explicit non-self canonicals (rare).
    */
   path?: string;
   url?: string;
@@ -50,8 +37,8 @@ export function DynamicMeta({
   type = 'website',
 }: DynamicMetaProps) {
   const origin = getOrigin();
-  const resolvedUrl = url ?? (origin ? `${origin}${path ?? '/'}` : null);
-  const resolvedImage = image ?? (origin ? `${origin}${FALLBACK_IMAGE}` : null);
+  const resolvedUrl = url ?? `${origin}${path ?? '/'}`;
+  const resolvedImage = image ?? `${origin}${FALLBACK_IMAGE}`;
 
   return (
     <Helmet>
@@ -59,18 +46,18 @@ export function DynamicMeta({
       <meta name="description" content={description} />
 
       <meta property="og:type" content={type} />
-      {resolvedUrl && <meta property="og:url" content={resolvedUrl} />}
+      <meta property="og:url" content={resolvedUrl} />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
-      {resolvedImage && <meta property="og:image" content={resolvedImage} />}
+      <meta property="og:image" content={resolvedImage} />
 
       <meta name="twitter:card" content="summary_large_image" />
-      {resolvedUrl && <meta name="twitter:url" content={resolvedUrl} />}
+      <meta name="twitter:url" content={resolvedUrl} />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
-      {resolvedImage && <meta name="twitter:image" content={resolvedImage} />}
+      <meta name="twitter:image" content={resolvedImage} />
 
-      {resolvedUrl && <link rel="canonical" href={resolvedUrl} />}
+      <link rel="canonical" href={resolvedUrl} />
     </Helmet>
   );
 }

--- a/frontend/src/components/marketing/Footer.tsx
+++ b/frontend/src/components/marketing/Footer.tsx
@@ -48,7 +48,7 @@ export const Footer: React.FC = () => {
           <h4 className={styles.footerHeading}>Resources</h4>
           <ul className={styles.footerList}>
             <li className={styles.footerListItem}>
-              <a href="https://docs.torale.ai">Docs</a>
+              <a href="https://docs.webwhen.ai">Docs</a>
             </li>
             <li className={styles.footerListItem}>
               <a href="https://github.com/prassanna-ravishankar/torale">GitHub</a>


### PR DESCRIPTION
## Summary

Cleanup pass for #294 ([findings comment](https://github.com/prassanna-ravishankar/torale/issues/294#issuecomment-4383169058)) — anything still pointing at \`torale.ai\` on a crawler-visible surface that won't break a customer contract:

- **backend RSS channel**: "Torale Changelog" → "webwhen changelog" with matching webwhen-voice description
- **backend \`frontend_url\` default**: \`torale.ai\` → \`webwhen.ai\`. Prod overrides via env, so the default was only load-bearing for local dev / new envs — but a wrong default is a footgun for any sentinel that compares against it (cf. the original robots.txt bug in #296)
- **frontend \`index.html\`**: \`preconnect\` → \`api.webwhen.ai\`. Comment said "flips at cutover"; cutover landed in #267
- **frontend \`security.txt\`**: contact + canonical on \`webwhen.ai\`
- **frontend marketing footer**: Docs link → \`docs.webwhen.ai\` (was a 301 internal link)
- **docs-site marketing cross-links**: \`torale.ai/concepts/*\` and \`torale.ai\` signup link → \`webwhen.ai\`

## Deliberately out of scope

- **Privacy/Terms mailto addresses** (\`@torale.ai\`) — need MX confirmation before flipping. Filing as follow-up
- **Webhook header names** (\`X-Torale-*\`) — customer-facing contract, needs deprecation/migration plan. Filing as follow-up
- **SDK code samples in \`docs-site/sdk/*\`** — docs' own transition policy explicitly defers the package rename to a later phase
- **GitHub repo URL** (\`github.com/prassanna-ravishankar/torale\`) — repo wasn't renamed

## Test plan

- [x] \`npm run build\` (frontend) succeeds; prerender postcondition passes
- [x] \`npm run docs:build\` succeeds
- [x] \`uv run ruff check\` clean on touched backend files
- [ ] CI green
- [ ] Post-deploy: \`curl https://webwhen.ai/changelog.xml\` shows \"webwhen changelog\" channel title
- [ ] Post-deploy: \`curl https://webwhen.ai/.well-known/security.txt\` shows webwhen contact

Refs #294