### PR TITLE
chore(staging): retire legacy staging.torale.ai routes (#281 PR 2/2)

### DIFF
--- a/helm/torale/templates/configmap.yaml
+++ b/helm/torale/templates/configmap.yaml
@@ -18,13 +18,13 @@ data:
   AGENT_URL: {{ printf "http://%s-agent-free" (include "torale.fullname" .) | quote }}
 
   # API + frontend self-URLs (used for email links, OAuth callbacks, etc.).
-  # Post-cutover (production), the live hosts are .Values.domains.live.*;
-  # .Values.domains.legacy.* is pinned to torale.ai as the 301-redirect
-  # source in httproute.yaml. On surfaces with no parallel-route setup
-  # (staging, dev), domains.live is absent and the legacy keys ARE the
-  # live hosts — the dig fallback below handles that.
-  API_URL: {{ printf "https://%s" (default .Values.domains.legacy.api (dig "live" "api" "" .Values.domains)) | quote }}
-  FRONTEND_URL: {{ printf "https://%s" (default .Values.domains.legacy.frontend (dig "live" "frontend" "" .Values.domains)) | quote }}
+  # Resolution order: live first (post-cutover hostname), then legacy (the
+  # rebrand-source hostname when both render in parallel during a soak), then
+  # blank. `dig` returns "" when the path is missing so this stays safe even
+  # if either block is absent — e.g. post-#281-PR-2 staging has no legacy
+  # block at all and the live hostname carries the URL on its own.
+  API_URL: {{ printf "https://%s" (coalesce (dig "live" "api" "" .Values.domains) (dig "legacy" "api" "" .Values.domains)) | quote }}
+  FRONTEND_URL: {{ printf "https://%s" (coalesce (dig "live" "frontend" "" .Values.domains) (dig "legacy" "frontend" "" .Values.domains)) | quote }}
 
   # Platform capacity
   MAX_USERS: {{ .Values.capacity.maxUsers | quote }}

--- a/helm/torale/templates/frontend-config.yaml
+++ b/helm/torale/templates/frontend-config.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.frontend.enabled -}}
 {{- /*
-Live API hostname. Post-cutover (production), the live host is
-.Values.domains.live.api; .Values.domains.legacy.api is pinned to torale.ai
-as the 301-redirect source (see httproute.yaml). On surfaces with no
-parallel-route setup (staging, dev, default chart values), domains.live is
-absent and the legacy key IS the live host. Fall back accordingly.
+Live API hostname. Resolution order: live first (post-cutover), then legacy
+(the rebrand-source). Both `dig` calls return "" when the path is missing,
+so this stays safe even if either block is absent (e.g. post-#281-PR-2
+staging has no legacy block).
 */ -}}
-{{- $apiHost := default .Values.domains.legacy.api (dig "live" "api" "" .Values.domains) -}}
+{{- $apiHost := coalesce (dig "live" "api" "" .Values.domains) (dig "legacy" "api" "" .Values.domains) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/torale/templates/httproute.yaml
+++ b/helm/torale/templates/httproute.yaml
@@ -10,6 +10,14 @@
   Pre-cutover (during the soak window), the torale routes serve normally.
 */}}
 {{- $isCutover := eq (.Values.httproute.cutover | toString) "true" -}}
+{{/*
+  Legacy HTTPRoutes (torale.ai / api.torale.ai / docs.torale.ai and their
+  staging counterparts) only render when .Values.domains.legacy is set. When
+  the legacy hostnames retire (e.g. staging.torale.ai → staging.webwhen.ai
+  cutover, #281 PR 2), drop the legacy block from the env's values and the
+  whole section below stops rendering.
+*/}}
+{{- if .Values.domains.legacy }}
 ---
 # Frontend HTTPRoute
 apiVersion: gateway.networking.k8s.io/v1
@@ -189,6 +197,7 @@ spec:
       weight: 1
   {{- end }}
 {{- end }}
+{{- end }}{{/* end if .Values.domains.legacy */}}
 
 # ============================================================================
 # webwhen.ai parallel routes (rebrand cutover)

--- a/helm/torale/values-staging.yaml
+++ b/helm/torale/values-staging.yaml
@@ -1,18 +1,13 @@
 # Staging values for Torale on GKE ClusterKit
-# Deployed to staging.webwhen.ai (cutover-in-progress; legacy staging.torale.ai
-# routes still render in parallel during the soak window of #281)
+# Deployed to staging.webwhen.ai (post-#281, legacy staging.torale.ai retired)
 
 domains:
-  legacy:
-    # Soak-window keep-alive. Both routes render in parallel; verify the
-    # webwhen.ai routes are healthy before retiring this block in PR 2.
-    frontend: staging.torale.ai
-    api: api-staging.torale.ai
-    docs: docs-staging.torale.ai
+  # Explicit null nulls out the global `values.yaml` legacy defaults so the
+  # legacy HTTPRoutes stop rendering (template gate on `if .Values.domains.legacy`).
+  # Staging is webwhen-only post-#281; wildcard *.webwhen.ai cert covers both
+  # hostnames.
+  legacy: ~
   live:
-    # Customer-facing post-#281. Wildcard *.webwhen.ai cert
-    # (webwhen-ai-origin-cert, attached to clusterkit-gateway via pre-shared
-    # annotation) covers both hostnames already; no per-host cert needed.
     frontend: staging.webwhen.ai
     api: api-staging.webwhen.ai
 
@@ -74,12 +69,8 @@ docs:
 # `Disallow: /` but X-Robots-Tag covers crawlers that ignore robots.txt.
 # Closes #280.
 #
-# Two flags, two scopes:
-# - stagingNoindex: applies to the legacy staging.torale.ai frontend catchall
-#   only (a $isStagingRelease-gated branch in httproute.yaml).
-# - noindex: applies to every webwhen-* route (the rebrand soak overlay's
-#   primary safety mechanism). Set true on staging because staging.webwhen.ai
-#   is also a non-production domain that should never be indexed.
+# stagingNoindex was the legacy-side flag (gated on $isStagingRelease,
+# applied to staging.torale.ai); now that legacy is retired, only the
+# webwhen-side `noindex` flag is load-bearing.
 httproute:
-  stagingNoindex: true
   noindex: true


### PR DESCRIPTION
## Summary

Closes #281 (PR 2 of 2). Retires the legacy `staging.torale.ai` / `api-staging.torale.ai` HTTPRoutes after the soak window from PR #295. Staging is now webwhen-only.

### Why retire (not 301)

Per orchestrator review: staging has no SEO equity, no external bookmarks worth a permanent redirect. Anyone hitting `staging.torale.ai` after this lands gets a connection error / 404 — clean signal to update bookmarks. Documented decision so a future contributor seeing 404 has the rationale.

### Scope was bigger than expected

The original plan was "remove the legacy block from values-staging.yaml" (4 lines). Turned out the chart's templates referenced `.Values.domains.legacy.*` directly with no presence guard, and the global `values.yaml` had legacy defaults that staging values would inherit even when omitted. So this PR also includes a small template refactor to make the legacy block optional:

1. **`templates/httproute.yaml`** — wraps the entire legacy section (frontend / api / docs HTTPRoutes) in `{{- if .Values.domains.legacy }} ... {{- end }}`. Routes only render when an env explicitly sets a legacy block.

2. **`templates/configmap.yaml`** + **`templates/frontend-config.yaml`** — switches the API_URL/FRONTEND_URL fallback from `default .Values.domains.legacy.api (dig "live" "api" "" .Values.domains)` to `coalesce (dig "live" "api" "" .Values.domains) (dig "legacy" "api" "" .Values.domains)`. Both `dig` calls return `""` when the path is missing, so this stays safe whether legacy or live (or both) are present. Same effective resolution order: live first, legacy second.

3. **`values-staging.yaml`** — removes the legacy block and explicitly sets `legacy: ~` to null out the global `values.yaml` legacy defaults that would otherwise inherit. Drops `httproute.stagingNoindex: true` (was the legacy-side flag; the webwhen-side `httproute.noindex: true` is what staging needs now).

### Diff verification

- **Staging render**: no more `staging.torale.ai` / `api-staging.torale.ai` HTTPRoutes. Only `staging.webwhen.ai` + `api-staging.webwhen.ai` render. API_URL/FRONTEND_URL still resolve to webwhen variants.
- **Production render diff vs main**: comment-text update + `checksum/configmap` hash shift (because the comment change reshapes the rendered ConfigMap, which reshapes the hash). The hash change will trigger one no-op api Deployment rollout on the next prod deploy — same image tag, just a fresh pod. No hostname / runtime-config drift.
- **Default render** (no env values): unchanged — global `values.yaml` still ships the torale.ai legacy block as the default when no env file is supplied.

## Test plan

- [x] `helm template … -f values-staging.yaml`: only `staging.webwhen.ai` + `api-staging.webwhen.ai` HTTPRoutes render. ConfigMap API_URL/FRONTEND_URL still webwhen variants.
- [x] `helm template … -f values-production.yaml` diff vs main: comment text + checksum hash only. All 7 prod hostnames preserved.
- [x] `helm template …` (no env values): default torale.ai legacy block still renders.
- [ ] **Post-merge**: dispatch staging deploy, verify `staging.torale.ai` returns connection error / 404 from edge AND origin. Verify `staging.webwhen.ai` still 200.
- [ ] **Manual cleanup post-merge**: delete orphaned `staging.torale.ai` / `api-staging.torale.ai` Cloudflare A/CNAME records (ExternalDNS upsert-only — won't delete on its own). Use `cf-dashboard` agent-browser session.

## Related

- #295 — PR 1 (parallel routes + CI improvements). Merged at ab17938.