### PR TITLE
fix(legal): flip mailto strings to webwhen.ai (#303)

### DIFF
--- a/frontend/src/pages/PrivacyPolicy.tsx
+++ b/frontend/src/pages/PrivacyPolicy.tsx
@@ -197,7 +197,7 @@ export function PrivacyPolicy() {
                 <li><strong>Restrict processing:</strong> Request limitations on how we use your data</li>
               </ul>
               <p>
-                To exercise these rights, contact <a href="mailto:privacy@torale.ai">privacy@torale.ai</a>.
+                To exercise these rights, contact <a href="mailto:privacy@webwhen.ai">privacy@webwhen.ai</a>.
                 We will respond within 30 days.
               </p>
 
@@ -211,7 +211,7 @@ export function PrivacyPolicy() {
               <h2>10. Children's Privacy</h2>
               <p>
                 The Service is not intended for users under 18 years of age. We do not knowingly collect personal information
-                from children. If you believe we have collected data from a child, contact <a href="mailto:privacy@torale.ai">privacy@torale.ai</a>.
+                from children. If you believe we have collected data from a child, contact <a href="mailto:privacy@webwhen.ai">privacy@webwhen.ai</a>.
               </p>
 
               <h2>11. Cookies and Tracking</h2>
@@ -236,7 +236,7 @@ export function PrivacyPolicy() {
               <p>
                 webwhen<br />
                 Privacy Officer<br />
-                Email: <a href="mailto:privacy@torale.ai">privacy@torale.ai</a>
+                Email: <a href="mailto:privacy@webwhen.ai">privacy@webwhen.ai</a>
               </p>
             </div>
           </div>

--- a/frontend/src/pages/TermsOfService.tsx
+++ b/frontend/src/pages/TermsOfService.tsx
@@ -105,7 +105,7 @@ export function TermsOfService() {
               </p>
               <p>
                 <strong>Your Rights:</strong> You may request data deletion, export your data,
-                or deactivate your account at any time by contacting <a href="mailto:support@torale.ai">support@torale.ai</a>.
+                or deactivate your account at any time by contacting <a href="mailto:support@webwhen.ai">support@webwhen.ai</a>.
               </p>
 
               <h2>6. Third-Party Services and AI Providers</h2>
@@ -172,7 +172,7 @@ export function TermsOfService() {
                 including for violations of these Terms.
               </p>
               <p>
-                You may terminate your account at any time by contacting <a href="mailto:support@torale.ai">support@torale.ai</a>.
+                You may terminate your account at any time by contacting <a href="mailto:support@webwhen.ai">support@webwhen.ai</a>.
                 Upon termination, your data will be retained for 90 days before permanent deletion.
               </p>
 
@@ -193,7 +193,7 @@ export function TermsOfService() {
               <p>For questions about these Terms, contact us at:</p>
               <p>
                 webwhen<br />
-                Email: <a href="mailto:legal@torale.ai">legal@torale.ai</a>
+                Email: <a href="mailto:legal@webwhen.ai">legal@webwhen.ai</a>
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Closes #303. Flips 6 mailto strings in `PrivacyPolicy.tsx` (3) + `TermsOfService.tsx` (3) from `*@torale.ai` to `*@webwhen.ai`. CF Email Routing on the `webwhen.ai` zone forwards `privacy@`, `support@`, `legal@webwhen.ai` to `me@prassanna.io` (inbound) and Workspace handles outbound send-as. Email stack is live; flipping the addresses unblocks GSC submission.

## Test plan

- [x] `npm run lint` clean (no new warnings)
- [x] grep verifies all 6 strings now @webwhen.ai with no torale.ai stragglers in these files
- [ ] Post-merge: spot-check `/privacy` + `/terms` rendered HTML in prod show webwhen.ai links