### PR TITLE
fix(seo): noindex catch-all 404 route + DynamicMeta noindex prop (#305)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ const ConnectorsPage = lazy(() => import('@/pages/ConnectorsPage').then(m => ({ 
 import { connectorsEnabled } from '@/components/connectors/connectorsFlag'
 const TermsOfService = lazy(() => import('@/pages/TermsOfService').then(m => ({ default: m.TermsOfService })))
 const PrivacyPolicy = lazy(() => import('@/pages/PrivacyPolicy').then(m => ({ default: m.PrivacyPolicy })))
+const NotFound = lazy(() => import('@/pages/NotFound'))
 const CapacityGate = lazy(() => import('@/components/CapacityGate').then(m => ({ default: m.CapacityGate })))
 const WaitlistPage = lazy(() => import('@/components/WaitlistPage').then(m => ({ default: m.WaitlistPage })))
 const Explore = lazy(() => import('@/pages/Explore').then(m => ({ default: m.Explore })))
@@ -274,6 +275,9 @@ export default function App() {
             </ProtectedRoute>
           }
         />
+        {/* Catch-all 404 — emits noindex so unknown URLs don't get indexed as
+            soft-404s. Must be last. See #305. */}
+        <Route path="*" element={<NotFound />} />
         </Routes>
       </Suspense>
       <Toaster />

--- a/frontend/src/components/DynamicMeta.tsx
+++ b/frontend/src/components/DynamicMeta.tsx
@@ -26,6 +26,12 @@ interface DynamicMetaProps {
   description?: string;
   image?: string;
   type?: 'website' | 'article';
+  /**
+   * When true, emits `<meta name="robots" content="noindex, nofollow">` and
+   * skips canonical / og:url / twitter:url. Used by the SPA catch-all 404
+   * route so unknown paths don't get indexed as soft-404s. See #305.
+   */
+  noindex?: boolean;
 }
 
 export function DynamicMeta({
@@ -35,10 +41,21 @@ export function DynamicMeta({
   description = 'Tell webwhen what to watch for in plain English. It will sit with the question, search the web on a schedule, and tell you the moment your condition is met.',
   image,
   type = 'website',
+  noindex = false,
 }: DynamicMetaProps) {
   const origin = getOrigin();
   const resolvedUrl = url ?? `${origin}${path ?? '/'}`;
   const resolvedImage = image ?? `${origin}${FALLBACK_IMAGE}`;
+
+  if (noindex) {
+    return (
+      <Helmet>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+        <meta name="robots" content="noindex, nofollow" />
+      </Helmet>
+    );
+  }
 
   return (
     <Helmet>

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,0 +1,40 @@
+import { Link } from 'react-router-dom'
+import { MarketingLayout } from '@/components/marketing/MarketingLayout'
+import { DynamicMeta } from '@/components/DynamicMeta'
+import { cn } from '@/lib/utils'
+import landingStyles from '@/components/landing/Landing.module.css'
+import marketingStyles from '@/components/marketing/marketing.module.css'
+
+// SPA catch-all route. Emits robots noindex so unknown paths aren't indexed
+// as soft-404s when the SPA fallback serves index.html with HTTP 200. See
+// #305 — Option A interim. The end-state Option B (real 404 status code at
+// the edge for non-prerendered paths) is tracked separately.
+export default function NotFound() {
+  return (
+    <>
+      <DynamicMeta
+        title="Not found — webwhen"
+        description="That page isn't here."
+        noindex
+      />
+      <MarketingLayout>
+        <section className={cn(landingStyles.section, marketingStyles.articleHero)}>
+          <div className={landingStyles.container}>
+            <div className={marketingStyles.reading}>
+              <div className={marketingStyles.articleHeroEyebrow}>404</div>
+              <h1 className={marketingStyles.articleHeading}>
+                That page <span className={marketingStyles.articleHeroEmber}>isn't here</span>.
+              </h1>
+              <p className={marketingStyles.articleLede}>
+                The URL you followed may be wrong, or the page may have moved.
+              </p>
+              <p className={marketingStyles.stamp}>
+                <Link to="/">Back to webwhen</Link>
+              </p>
+            </div>
+          </div>
+        </section>
+      </MarketingLayout>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary

Closes #305 with **Option A (interim)**. Adds a SPA-side catch-all `path="*"` → `<NotFound>` route that emits `<meta name="robots" content="noindex, nofollow">`. Crawlers running JS see the noindex directive and Search Console categorises matching URLs as "Excluded by 'noindex' tag" instead of soft-404.

### Layer-of-fix analysis

The SPA returns 200 for unknown paths because `frontend/nginx.conf` has `try_files $uri $uri.html /index.html;`. For a request like `/this-page-does-not-exist`:

1. **Cloudflare** — proxies through, doesn't override status.
2. **Gateway HTTPRoute** — matches `webwhen.ai/*` → frontend Service. Hits any path.
3. **nginx in the frontend container** — `$uri` doesn't exist as a file, `$uri.html` doesn't exist, so it falls through to `/index.html` with status 200.
4. **React Router (in browser)** — pre-this-PR, no catch-all; React Router silently rendered nothing for unknown paths. Post-this-PR, `<NotFound>` renders with noindex meta.

This PR addresses **layer 4 only**. Status is still 200; the noindex meta tells crawlers to skip the page rather than treat it as a real document. For SEO purposes, that's the same outcome as a 404 status code (URL stays out of the index).

### Known gap → Option B follow-up

JS-less crawlers (Bing, Yandex, social card scrapers) load the static HTML and don't run React Router. They see the unmodified SPA shell `index.html` baked at build time, which carries no noindex meta and renders as the home page content. So those crawlers can still index `/this-page-does-not-exist` as if it were a real page.

The fully correct fix is **Option B**: nginx serves a real 404 status for paths that don't match any known SPA route. Requires enumerating both public routes (already in `publicRoutes.ts`) AND auth routes (currently inline in `App.tsx`, no central source). That's a real refactor — extracting auth routes to a typed array, generating an nginx route map at build time, etc. Filing as a follow-up so this interim ships now.

### Component change

`DynamicMeta` gains an optional `noindex?: boolean` prop. When true, the component emits only `<title>`, `<meta name="description">`, and `<meta name="robots" content="noindex, nofollow">` — skipping canonical / og:url / twitter:url which are inappropriate for a not-found page.

## Test plan

- [x] `npm run lint` clean (only the pre-existing WatchList.tsx warning)
- [x] `npx tsc --noEmit` clean
- [ ] Post-merge prod: `curl https://webwhen.ai/this-page-does-not-exist` returns the SPA shell with status 200; loading in a browser renders the NotFound page with noindex meta; manually verify in DevTools that `<meta name="robots" content="noindex, nofollow">` is present in the rendered DOM.
- [ ] Existing valid routes still serve normally (`/`, `/changelog`, `/privacy`, `/terms`, `/sign-in`, `/dashboard`, etc.).
- [ ] GSC "Coverage > Excluded > Soft 404" report should drop after the next crawl as Google reclassifies these URLs under "Excluded by 'noindex' tag".

## Follow-up

Will file Option B as a separate issue: nginx-level real-404 with auth-route enumeration. That fix covers non-JS crawlers and is the correct end state.