### PR TITLE
chore(rebrand): update package metadata to webwhen.ai (#308)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
   "name": "torale",
   "owner": {
-    "name": "Torale",
-    "email": "hello@torale.ai"
+    "name": "webwhen",
+    "email": "hello@webwhen.ai"
   },
   "metadata": {
     "description": "AI-powered web monitoring plugins"
@@ -14,9 +14,9 @@
       "description": "Monitor the web for conditions and get notified when they're met",
       "version": "0.1.0",
       "author": {
-        "name": "Torale"
+        "name": "webwhen"
       },
-      "homepage": "https://torale.ai",
+      "homepage": "https://webwhen.ai",
       "keywords": ["monitoring", "web", "search", "alerts", "webhooks"],
       "category": "automation"
     }

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,10 +5,10 @@ description = "Grounded search monitoring platform for AI-powered conditional au
 requires-python = ">=3.11"
 license = {text = "MIT"}
 authors = [
-    {name = "Torale Team", email = "hello@torale.ai"}
+    {name = "webwhen", email = "hello@webwhen.ai"}
 ]
 maintainers = [
-    {name = "Torale Team", email = "hello@torale.ai"}
+    {name = "webwhen", email = "hello@webwhen.ai"}
 ]
 keywords = [
     "ai",
@@ -64,11 +64,11 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://torale.ai"
-Documentation = "https://github.com/prasadcode/torale#readme"
-Repository = "https://github.com/prasadcode/torale"
-"Bug Tracker" = "https://github.com/prasadcode/torale/issues"
-Changelog = "https://github.com/prasadcode/torale/releases"
+Homepage = "https://webwhen.ai"
+Documentation = "https://github.com/prassanna-ravishankar/torale#readme"
+Repository = "https://github.com/prassanna-ravishankar/torale"
+"Bug Tracker" = "https://github.com/prassanna-ravishankar/torale/issues"
+Changelog = "https://github.com/prassanna-ravishankar/torale/releases"
 
 [project.optional-dependencies]
 dev = [

--- a/plugin.json
+++ b/plugin.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "Monitor the web for conditions and get notified when they're met",
   "author": {
-    "name": "Torale",
-    "email": "hello@torale.ai"
+    "name": "webwhen",
+    "email": "hello@webwhen.ai"
   },
-  "homepage": "https://torale.ai",
+  "homepage": "https://webwhen.ai",
   "repository": "https://github.com/prassanna-ravishankar/torale",
   "license": "MIT",
   "skills": "./skills"


### PR DESCRIPTION
## Summary

Flip torale.ai → webwhen.ai in package metadata surfaces that crawlers and distributors see. Follow-up to #300 (which swept public visible surfaces) and sibling to #303 (legal mailto flip).

- `plugin.json`: author name + email + homepage
- `.claude-plugin/marketplace.json`: owner + plugin author + homepage
- `backend/pyproject.toml`: authors/maintainers + project URLs (also fixes wrong `prasadcode/torale` repo URLs to the actual `prassanna-ravishankar/torale`)

## Out of scope

Per #308's recommendation, **slugs are unchanged** (`name: torale` in plugin.json, marketplace.json, and pyproject.toml). Renaming the slug breaks anyone who installed the plugin as `torale` or pip-pinned the package. Slug rename should be a separate, deliberate decision.

Closes #308.

## Test plan
- [x] `git diff --stat` reviewed — 3 files, metadata only
- [x] No other torale.ai / hello@torale references in package metadata files (`grep -r torale.ai --include=*.toml --include=package.json --include=plugin.json --include=marketplace.json`)