### PR TITLE
feat(seo): BreadcrumbList JSON-LD on /compare /use-cases /concepts (#304)

### DIFF
--- a/frontend/src/pages/ComparePage.tsx
+++ b/frontend/src/pages/ComparePage.tsx
@@ -5,6 +5,8 @@ import { cn } from '@/lib/utils';
 import landingStyles from '@/components/landing/Landing.module.css';
 import marketingStyles from '@/components/marketing/marketing.module.css';
 import { COMPETITORS } from '@/data/competitors';
+import { generateBreadcrumbStructuredData } from '@/utils/structuredData';
+import { escapeForScriptTag } from '@/utils/jsonLd';
 
 /**
  * Editorial comparison page — webwhen vs a single competitor.
@@ -21,12 +23,24 @@ export function ComparePage() {
 
   const competitor = COMPETITORS[tool];
 
+  const breadcrumbJson = JSON.stringify(
+    generateBreadcrumbStructuredData([
+      { name: 'Home', path: '/' },
+      { name: 'Compare', path: '/compare' },
+      { name: competitor.name, path: `/compare/${competitor.slug}` },
+    ]),
+  );
+
   return (
     <MarketingLayout activePath="/compare">
       <DynamicMeta
         path={`/compare/${competitor.slug}`}
         title={competitor.seoTitle}
         description={competitor.seoDescription}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: escapeForScriptTag(breadcrumbJson) }}
       />
 
       {/* Hero — smaller than Landing's */}

--- a/frontend/src/pages/ConceptPage.tsx
+++ b/frontend/src/pages/ConceptPage.tsx
@@ -5,6 +5,8 @@ import { cn } from '@/lib/utils';
 import landingStyles from '@/components/landing/Landing.module.css';
 import marketingStyles from '@/components/marketing/marketing.module.css';
 import { CONCEPTS } from '@/data/concepts';
+import { generateBreadcrumbStructuredData } from '@/utils/structuredData';
+import { escapeForScriptTag } from '@/utils/jsonLd';
 
 /**
  * Concept landing page: editorial explainer for webwhen's conceptual surfaces.
@@ -19,6 +21,14 @@ export function ConceptPage() {
 
   const data = CONCEPTS[concept];
 
+  const breadcrumbJson = JSON.stringify(
+    generateBreadcrumbStructuredData([
+      { name: 'Home', path: '/' },
+      { name: 'Concepts', path: '/concepts' },
+      { name: data.title, path: `/concepts/${data.slug}` },
+    ]),
+  );
+
   return (
     <MarketingLayout activePath="/concepts">
       <DynamicMeta
@@ -26,6 +36,10 @@ export function ConceptPage() {
         title={data.metaTitle}
         description={data.metaDescription}
         type="article"
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: escapeForScriptTag(breadcrumbJson) }}
       />
 
       <section className={cn(landingStyles.section, marketingStyles.articleHero)}>

--- a/frontend/src/pages/UseCasePage.tsx
+++ b/frontend/src/pages/UseCasePage.tsx
@@ -5,6 +5,8 @@ import { cn } from '@/lib/utils';
 import landingStyles from '@/components/landing/Landing.module.css';
 import marketingStyles from '@/components/marketing/marketing.module.css';
 import { USE_CASES } from '@/data/useCases';
+import { generateBreadcrumbStructuredData } from '@/utils/structuredData';
+import { escapeForScriptTag } from '@/utils/jsonLd';
 
 /**
  * Editorial use-case landing page.
@@ -20,12 +22,24 @@ export function UseCasePage() {
   const useCase = USE_CASES[usecase];
   const others = Object.values(USE_CASES).filter((u) => u.slug !== useCase.slug);
 
+  const breadcrumbJson = JSON.stringify(
+    generateBreadcrumbStructuredData([
+      { name: 'Home', path: '/' },
+      { name: 'Use cases', path: '/use-cases' },
+      { name: useCase.name, path: `/use-cases/${useCase.slug}` },
+    ]),
+  );
+
   return (
     <MarketingLayout activePath="/use-cases">
       <DynamicMeta
         path={`/use-cases/${useCase.slug}`}
         title={useCase.seoTitle ?? `${useCase.heroHeadline} — webwhen`}
         description={useCase.seoDescription ?? useCase.heroLede}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: escapeForScriptTag(breadcrumbJson) }}
       />
 
       {/* Hero */}

--- a/frontend/src/utils/structuredData.ts
+++ b/frontend/src/utils/structuredData.ts
@@ -20,6 +20,33 @@ export function generateOrganizationStructuredData() {
   };
 }
 
+/**
+ * One step in a breadcrumb trail. `path` is a site-root path
+ * (e.g. "/compare/visualping-alternative") — the helper resolves it to a
+ * full URL using the prerender-time origin via getOrigin().
+ *
+ * Keep the trail in nav-hierarchy order, leaf last. Last item's path can be
+ * the page itself (Google accepts that and treats it as the current page).
+ */
+export interface BreadcrumbItem {
+  name: string;
+  path: string;
+}
+
+export function generateBreadcrumbStructuredData(items: BreadcrumbItem[]) {
+  const origin = getOrigin();
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, idx) => ({
+      "@type": "ListItem",
+      position: idx + 1,
+      name: item.name,
+      item: `${origin}${item.path}`,
+    })),
+  };
+}
+
 export function generateFAQStructuredData(items: FAQItem[]) {
   return {
     "@context": "https://schema.org",


### PR DESCRIPTION
## Summary

Closes #304. Adds `BreadcrumbList` schema.org JSON-LD to the three editorial route shapes that lacked it. SERPs render breadcrumb paths when this is present — small but real CTR boost on long-tail pages.

### Pattern

Extracted a typed helper `generateBreadcrumbStructuredData(items: BreadcrumbItem[])` in `utils/structuredData.ts`. Each page builds its trail from explicit `{ name, path }` items and renders the JSON-LD inline via `escapeForScriptTag` (same boundary contract used by `Changelog.tsx` and `OrganizationJsonLd.tsx`). URLs resolve via `getOrigin()` so the prerender bakes the right env-specific origin (webwhen.ai for prod, `PRERENDER_ORIGIN` override for staging).

### Per-route trail

| Route | Trail |
|---|---|
| `/compare/{slug}` | Home → Compare → {competitor.name} (e.g. "VisualPing") |
| `/use-cases/{slug}` | Home → Use cases → {useCase.name} (e.g. "Competitor pricing watches" — the short tab label, not the long hero headline) |
| `/concepts/{slug}` | Home → Concepts → {concept.title} |

### Per orchestrator review

> "Make sure the breadcrumb structure matches the actual nav hierarchy and is kept in sync as the IA evolves — extract a typed helper, don't hardcode."

- Helper takes a typed `BreadcrumbItem[]`, callers compose. No JSON blobs hardcoded in page bodies.
- Trail `name`s come from the existing data files (`competitors.ts`, `useCases.ts`, `concepts.ts`) — single source of truth. If we rename a competitor or use case, the breadcrumb name flows automatically.
- Dropped first iteration's use of `useCase.heroHeadline` (full sentence, ugly in SERP) in favour of `useCase.name` (short tab label).

## Test plan

- [x] `npm run lint` clean (only pre-existing WatchList warning)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds; prerender postcondition passes
- [x] Verified prerendered HTML for each shape contains `"@type":"BreadcrumbList"` with correct trail:
  - `/compare/visualping-alternative`: Home → Compare → VisualPing ✓
  - `/use-cases/competitor-price-change-monitor`: Home → Use cases → Competitor pricing watches ✓
  - `/concepts/self-scheduling-agents`: Home → Concepts → Self-scheduling agents ✓
- [ ] **Post-merge**: Google Rich Results Test on each route should detect BreadcrumbList. schema.org validator clean.

## Coordination

No overlap with the LCP perf chain (peer is on docs-site mermaid/katex preload + frontend index.html font preload + nginx cache splits). My change is page-component-only.