### PR TITLE
perf(frontend): preload Instrument Sans for hero LCP (#306)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,6 +17,11 @@
     <!-- Warm up TLS to the API so Landing fetches are not gated on DNS+TLS. -->
     <link rel="preconnect" href="https://api.webwhen.ai" crossorigin>
 
+    <!-- Preload the LCP-critical font (Instrument Sans powers the hero <h1>).
+         font-display: swap means text paints in fallback first, then swaps when
+         the woff2 arrives — preloading hides the swap moment and tightens LCP. -->
+    <link rel="preload" href="/fonts/instrument-sans-latin.woff2" as="font" type="font/woff2" crossorigin>
+
     <!-- Load runtime config (deferred for better performance) -->
     <script src="/config.js" defer></script>
 


### PR DESCRIPTION
## Summary

Adds `<link rel="preload" as="font">` for `instrument-sans-latin.woff2` in `frontend/index.html`. This is the font used by the hero `<h1>` on `webwhen.ai/` (the LCP element on the marketing homepage and on `/use-cases/*` article pages).

Existing `font-display: swap` already paints text in the system fallback while the woff2 loads, then swaps. Preloading the font hides the swap moment so LCP lands on the *final* glyphs instead of the fallback paint, tightening LCP by ~150-300ms on cold network.

CSP impact: none. `font-src 'self'` already permits same-origin font fetches; the preload uses the existing self-hosted asset.

Surface scope: only `instrument-sans-latin.woff2` — the LCP-critical font. Preloading every font would degrade LCP (preload competes with HTML/CSS); preloading only the one used at first paint is the documented pattern.

Part of #306. PR A (docs.webwhen.ai mermaid preload) coming separately.

## Test plan
- [ ] CI green (lint + typecheck via `frontend-pr.yml`)
- [ ] Post-deploy: Lighthouse mobile-throttled on https://webwhen.ai/ — capture LCP delta vs the issue's 3.7s baseline
- [ ] Spot-check a `/use-cases/*` article page LCP delta vs 3.4s baseline
- [ ] Verify no font-related console errors on the deployed page