### PR TITLE
perf(docs): demote mermaid+katex preloads to prefetch (#306)

### DIFF
--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -30,6 +30,18 @@ export default withMermaid(
     /^http:\/\/localhost/
   ],
 
+  // Mermaid pulls in 30+ diagram chunks via dynamic import; without this filter
+  // VitePress emits `<link rel="modulepreload">` for every one of them (plus
+  // katex, dagre, cose-bilkent) on every page, including the home page which
+  // has zero diagrams. Only one page in the site (architecture/self-scheduling-
+  // agents) actually renders mermaid. Demoting these to `<link rel="prefetch">`
+  // via `shouldPreload` lets the browser still grab them on idle bandwidth so
+  // mermaid renders fast on the one page that uses it, without contending with
+  // the LCP on every other page. ~600KB of contention dropped from first paint.
+  // See #306.
+  shouldPreload: (link, _page) =>
+    !/(?:Diagram|diagram-|katex|dagre|cose-bilkent|-definition|virtual_mermaid)/.test(link),
+
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }],
     ['link', { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/logo-32.png' }],


### PR DESCRIPTION
## Summary

`docs.webwhen.ai/` was scoring **LCP 5.5s 🔴 / Perf 0.67** in prod (per #306). Root cause: `vitepress-plugin-mermaid` causes VitePress to emit `<link rel="modulepreload">` for **35 dynamic-import chunks** on every page — every diagram type (`flowDiagram`, `erDiagram`, `gitGraphDiagram`, `ganttDiagram`, etc.), `katex` (259KB), `dagre`, `cose-bilkent`. **Only one page in the entire site** (`architecture/self-scheduling-agents.md`) actually renders a mermaid diagram. The home page renders zero. So the home page was racing 35 modulepreload fetches against the actual page's first paint.

This PR adds VitePress's `shouldPreload(link, page)` config to demote those chunks to `<link rel="prefetch">` instead. Browser still fetches them on idle bandwidth, so mermaid renders fast on the architecture page. They no longer contend with LCP on the other ~25 pages.

After patch (verified locally via `vitepress preview` + Lighthouse mobile-throttled):

| Metric | Before (prod) | After (local) |
|---|---|---|
| LCP | 5.6s 🔴 | **2.4s 🟡→🟢** |
| Performance | 0.66 | **0.95** |
| FCP | 5.3s | 2.3s |
| CLS | 0 | 0 |

Localhost has no network latency so prod LCP will be modestly higher than 2.4s, but the relative improvement (32 fewer competing fetches) holds. Will re-run Lighthouse against prod after deploy.

Build verification:
- Home page modulepreloads: 35 → 3 (framework + theme + page lean.js — all expected entry chunks)
- Architecture page (the one mermaid page): 35 → 3 modulepreloads + 25 prefetches (mermaid still loads on demand)
- Mermaid runtime behaviour unchanged — chunks still load via dynamic `import()` when a `<Mermaid>` component mounts

Part of #306.

## Test plan
- [ ] CI green
- [ ] Post-deploy: Lighthouse mobile-throttled on https://docs.webwhen.ai/ — capture LCP delta vs 5.5s baseline
- [ ] Smoke-check https://docs.webwhen.ai/architecture/self-scheduling-agents — confirm mermaid diagrams still render
- [ ] Spot-check 1-2 other docs pages for general functionality