### PR TITLE
feat(webhooks): rename X-Torale-* → X-Webwhen-* headers (#302)

### DIFF
--- a/backend/src/torale/notifications/webhook.py
+++ b/backend/src/torale/notifications/webhook.py
@@ -26,7 +26,7 @@ class WebhookPayload(BaseModel):
     event_type: Literal["task.condition_met"]
     created_at: int  # Unix timestamp
 
-    # Torale metadata
+    # webwhen metadata
     object: str = "event"
     api_version: str = "v1"
 
@@ -123,11 +123,11 @@ class WebhookDeliveryService:
         # Prepare headers (following GitHub/Stripe conventions)
         headers = {
             "Content-Type": "application/json",
-            "User-Agent": "Torale-Webhooks/1.0",
-            "X-Torale-Event": payload.event_type,
-            "X-Torale-Signature": signature,
-            "X-Torale-Delivery": payload.id,
-            "X-Torale-Timestamp": str(timestamp),
+            "User-Agent": "Webwhen-Webhooks/1.0",
+            "X-Webwhen-Event": payload.event_type,
+            "X-Webwhen-Signature": signature,
+            "X-Webwhen-Delivery": payload.id,
+            "X-Webwhen-Timestamp": str(timestamp),
         }
 
         if custom_headers:

--- a/backend/static/changelog.json
+++ b/backend/static/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "id": "2026-05-05-webhook-headers-renamed",
+    "date": "2026-05-05",
+    "title": "Webhook headers renamed to X-Webwhen-*",
+    "description": "Webhook delivery headers were renamed as part of the rebrand from Torale to webwhen. The four custom headers (Event, Signature, Delivery, Timestamp) now use the X-Webwhen-* prefix instead of X-Torale-*, and the User-Agent string is now Webwhen-Webhooks/1.0. If you have any webhook receivers that parse these headers — particularly any signature-verification code matching on X-Torale-Signature — update them to the new names.",
+    "category": "infra",
+    "requestedBy": [],
+    "pr": 314
+  },
+  {
     "id": "2026-04-26-custom-connectors",
     "date": "2026-04-26",
     "title": "Custom Connectors: Notion, Linear, GitHub",

--- a/backend/static/changelog.json
+++ b/backend/static/changelog.json
@@ -6,7 +6,7 @@
     "description": "Webhook delivery headers were renamed as part of the rebrand from Torale to webwhen. The four custom headers (Event, Signature, Delivery, Timestamp) now use the X-Webwhen-* prefix instead of X-Torale-*, and the User-Agent string is now Webwhen-Webhooks/1.0. If you have any webhook receivers that parse these headers — particularly any signature-verification code matching on X-Torale-Signature — update them to the new names.",
     "category": "infra",
     "requestedBy": [],
-    "pr": 314
+    "pr": 315
   },
   {
     "id": "2026-04-26-custom-connectors",

--- a/backend/test_webhook.py
+++ b/backend/test_webhook.py
@@ -70,10 +70,10 @@ async def main():
     # Show headers that would be sent
     print("Headers that would be sent:")
     print("Content-Type: application/json")
-    print("User-Agent: Torale-Webhooks/1.0")
-    print("X-Torale-Event: task.condition_met")
-    print(f"X-Torale-Signature: {signature}")
-    print(f"X-Torale-Delivery: {payload.id}")
+    print("User-Agent: Webwhen-Webhooks/1.0")
+    print("X-Webwhen-Event: task.condition_met")
+    print(f"X-Webwhen-Signature: {signature}")
+    print(f"X-Webwhen-Delivery: {payload.id}")
     print()
 
     print("\n✓ Webhook test data generated!")
@@ -84,9 +84,9 @@ async def main():
     print()
     print("curl -X POST https://webhook.site/YOUR-ID \\")
     print("  -H 'Content-Type: application/json' \\")
-    print("  -H 'X-Torale-Event: task.condition_met' \\")
-    print(f"  -H 'X-Torale-Signature: {signature}' \\")
-    print(f"  -H 'X-Torale-Delivery: {payload.id}' \\")
+    print("  -H 'X-Webwhen-Event: task.condition_met' \\")
+    print(f"  -H 'X-Webwhen-Signature: {signature}' \\")
+    print(f"  -H 'X-Webwhen-Delivery: {payload.id}' \\")
     print(f"  -d '{payload_json}'")
 
 

--- a/backend/tests/test_webhook.py
+++ b/backend/tests/test_webhook.py
@@ -276,6 +276,6 @@ class TestWebhookDeliveryService:
         headers = call_kwargs["headers"]
 
         assert headers["Content-Type"] == "application/json"
-        assert "X-Torale-Signature" in headers
-        assert headers["X-Torale-Event"] == "task.condition_met"
-        assert "X-Torale-Delivery" in headers
+        assert "X-Webwhen-Signature" in headers
+        assert headers["X-Webwhen-Event"] == "task.condition_met"
+        assert "X-Webwhen-Delivery" in headers

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -154,7 +154,7 @@ webwhen requires webhook URLs to use HTTPS. If your OpenClaw instance runs local
 
 ## Authentication
 
-webwhen uses HMAC-SHA256 signing (Stripe-compatible) on every webhook delivery. The signature is in the `X-Torale-Signature` header (header name preserved during the transition). OpenClaw authenticates via the `Authorization: Bearer` header you configure in the notification.
+webwhen uses HMAC-SHA256 signing (Stripe-compatible) on every webhook delivery. The signature is in the `X-Webwhen-Signature` header. OpenClaw authenticates via the `Authorization: Bearer` header you configure in the notification.
 
 ## Rate limits
 

--- a/frontend/src/components/settings/WebhookConfigSection.tsx
+++ b/frontend/src/components/settings/WebhookConfigSection.tsx
@@ -276,7 +276,7 @@ export const WebhookConfigSection: React.FC = () => {
           <div>
             <h4 className={styles.sectionLabel} style={{ marginBottom: 6 }}>Signature header</h4>
             <code style={{ color: 'var(--ww-success)' }}>
-              X-Torale-Signature: t=&lt;timestamp&gt;,v1=&lt;signature&gt;
+              X-Webwhen-Signature: t=&lt;timestamp&gt;,v1=&lt;signature&gt;
             </code>
           </div>
 
@@ -284,9 +284,9 @@ export const WebhookConfigSection: React.FC = () => {
             <h4 className={styles.sectionLabel} style={{ marginBottom: 6 }}>Headers</h4>
             <ul className="space-y-1" style={{ color: 'var(--ww-ink-5)' }}>
               <li><code style={{ color: 'var(--ww-ink-7)' }}>Content-Type:</code> application/json</li>
-              <li><code style={{ color: 'var(--ww-ink-7)' }}>User-Agent:</code> Torale-Webhooks/1.0</li>
-              <li><code style={{ color: 'var(--ww-ink-7)' }}>X-Torale-Event:</code> task.condition_met</li>
-              <li><code style={{ color: 'var(--ww-ink-7)' }}>X-Torale-Delivery:</code> [execution_id]</li>
+              <li><code style={{ color: 'var(--ww-ink-7)' }}>User-Agent:</code> Webwhen-Webhooks/1.0</li>
+              <li><code style={{ color: 'var(--ww-ink-7)' }}>X-Webwhen-Event:</code> task.condition_met</li>
+              <li><code style={{ color: 'var(--ww-ink-7)' }}>X-Webwhen-Delivery:</code> [execution_id]</li>
             </ul>
           </div>
 


### PR DESCRIPTION
## Summary

Closes #302. Renames the four custom webhook headers and User-Agent from the old brand to the new one. Per orchestrator + Prass: nobody is using this surface yet, so no deprecation dance — single PR, outright rename.

| Old | New |
|---|---|
| `X-Torale-Event` | `X-Webwhen-Event` |
| `X-Torale-Signature` | `X-Webwhen-Signature` |
| `X-Torale-Delivery` | `X-Webwhen-Delivery` |
| `X-Torale-Timestamp` | `X-Webwhen-Timestamp` |
| `User-Agent: Torale-Webhooks/1.0` | `User-Agent: Webwhen-Webhooks/1.0` |

(Issue body listed 3 of 4 headers; whole-repo grep caught `X-Torale-Timestamp` too.)

### Surfaces touched

- `backend/src/torale/notifications/webhook.py` — emit code (the load-bearing one). Plus a code-comment update from "Torale metadata" → "webwhen metadata".
- `backend/tests/test_webhook.py` — three assertions flipped to `X-Webwhen-*`.
- `backend/test_webhook.py` — manual smoke script's print() lines (informational; the curl command it prints now uses the new names).
- `frontend/src/components/settings/WebhookConfigSection.tsx` — user-facing docs of header names. No transitional callout — the rename is clean.
- `docs-site/integrations/openclaw.md` — flipped header name. Removed the "header name preserved during the transition" parenthetical (no transition; it's just the name).
- `backend/static/changelog.json` — defensive entry: "if you have any external receivers, update them. Particularly any signature-verification code matching on X-Torale-Signature."

### What's NOT in this PR (per orchestrator)

- No Phase 2 issue.
- No customer email — Prass confirmed no users on the surface yet.
- No sunset header / dual-emit.

## Test plan

- [x] `uv run pytest backend/tests/test_webhook.py` — 14 passed
- [x] `npm run lint` (frontend) clean (only pre-existing WatchList warning)
- [x] Whole-repo grep confirms zero `X-Torale-` or `Torale-Webhooks` strings remain in `backend/`, `frontend/`, `docs-site/`
- [x] Whole-repo grep confirms `X-Webwhen-` and `Webwhen-Webhooks` present in all 5 expected files
- [x] changelog.json passes `python3 -c "import json; json.load(...)"`
- [ ] Post-merge: trigger a webhook delivery against staging via the existing test_webhook.py manual smoke or a real watch fire. Inspect headers received by the endpoint match the new names.