### PR TITLE
fix(prerender): eliminate React #418/#423 hydration warnings (#299)

### DIFF
--- a/frontend/scripts/prerender.mjs
+++ b/frontend/scripts/prerender.mjs
@@ -36,13 +36,29 @@ if (!existsSync(configPath)) {
   writeFileSync(configPath, 'window.CONFIG = {};', 'utf-8');
 }
 
-// Serve dist/ on a local port
-const server = http.createServer((req, res) =>
-  handler(req, res, {
-    public: DIST,
-    rewrites: [{ source: '**', destination: '/index.html' }],
-  })
-);
+// Snapshot the original SPA shell BEFORE any prerender runs. Once we start
+// writing route outputs, `/` writes back to `dist/index.html`, clobbering
+// the empty-root shell. Subsequent route passes would then load the
+// populated `/` HTML, see `root.children.length > 0` in main.tsx, call
+// `hydrateRoot()` against the previous route's DOM, and emit React #418/#423
+// on every pass after the first. Real users never hit this — they get the
+// per-route .html with matching content. Serve the in-memory shell for any
+// rewritten path so each pass starts against an empty root. See #299.
+const SHELL_HTML = readFileSync(join(DIST, 'index.html'), 'utf-8');
+
+// Serve dist/ on a local port. SPA-rewrite paths (anything that would
+// otherwise fall back to /index.html) get the original shell from memory.
+// Real assets pass through to serve-handler.
+const ASSET_PATH = /\.[a-zA-Z0-9]+$/; // any path ending in an extension is a real file
+const server = http.createServer((req, res) => {
+  const url = req.url || '/';
+  if (url === '/' || url === '/index.html' || !ASSET_PATH.test(url.split('?')[0])) {
+    res.setHeader('content-type', 'text/html; charset=utf-8');
+    res.end(SHELL_HTML);
+    return;
+  }
+  handler(req, res, { public: DIST });
+});
 
 const [{ PUBLIC_ROUTES }, browser] = await Promise.all([
   loadTsModule(join(PROJECT_ROOT, 'src/data/publicRoutes.ts')),

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -60,10 +60,21 @@ const PendingAuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 }
 
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
-  const noAuth = import.meta.env.VITE_TORALE_NOAUTH === '1' || window.__PRERENDER__
-
-  if (noAuth) {
+  // VITE_TORALE_NOAUTH is the local-dev escape hatch — runs against a mocked
+  // user end-to-end. NoAuthProvider returns a stable mock user so dev flows
+  // work without Clerk.
+  if (import.meta.env.VITE_TORALE_NOAUTH === '1') {
     return <NoAuthProvider>{children}</NoAuthProvider>
+  }
+
+  // Prerender uses the same "not yet loaded" shape that the runtime Suspense
+  // fallback emits — both produce HTML matching `user: null, isLoaded: false`.
+  // Without this, the prerender baked a logged-in mock user (NoAuthProvider's
+  // default) into HTML, and the runtime ClerkAuthProvider's Suspense fallback
+  // hydrated against null, tripping React #418/#423 hydration mismatches on
+  // every marketing route. See #299.
+  if (window.__PRERENDER__) {
+    return <PendingAuthProvider>{children}</PendingAuthProvider>
   }
 
   return (


### PR DESCRIPTION
## Summary

Closes #299. Eliminates React #418/#423 hydration warnings during prerender by fixing two distinct issues. Net result: `npm run build` emits **0 hydration errors** (was 33 across every marketing route).

### Issue 1: AuthProvider mismatch between prerender and runtime hydration

`AuthContext.tsx` routed both `__PRERENDER__` and `VITE_TORALE_NOAUTH` to `NoAuthProvider`, which returns a stable mock user. So the prerender baked a logged-in `<a href="/dashboard">Dashboard</a>` into Nav. At runtime hydration, the real `ClerkAuthProvider` lazy-loads behind a Suspense fallback (`PendingAuthProvider`) which returns `user: null`, so Nav rendered the unauthenticated `Sign in / Start watching` cluster. Different DOM = #418.

**Fix**: split the two no-auth use cases. `VITE_TORALE_NOAUTH` (local-dev mock) keeps `NoAuthProvider`. `__PRERENDER__` now uses the same `PendingAuthProvider` shape that the runtime Suspense fallback emits — both produce `user: null, isLoaded: false`, so the prerender bake matches the first runtime paint.

After this fix the baked HTML for /privacy etc. shows the unauthenticated cluster, which is the correct seed state for crawlers and first paints anyway.

### Issue 2: prerender script clobbering its own SPA shell

`scripts/prerender.mjs` processes routes in order: `/` first, writing back to `dist/index.html`. Subsequent routes' Playwright passes load that POPULATED `index.html` (the SPA-rewrite fallback served any path through it), which means `root.children.length > 0` in `main.tsx`, which calls `hydrateRoot()` instead of `createRoot()`, attempting to hydrate the previous route's DOM as the current route. Mismatch every time. **Real users never hit this** — they get the per-route `.html` with matching content — but the build log was full of misleading hydration noise that drowned out real regressions.

**Fix**: snapshot the original empty SPA shell into memory before any prerender runs. The local serve handler now returns the in-memory shell for any HTML-ish request (anything without a file extension), so each prerender pass starts against an empty root and React calls `createRoot()` cleanly. Real assets still pass through to `serve-handler`.

## Layer-of-fix

- `frontend/src/contexts/AuthContext.tsx` — runtime React tree (production fix; affects the actual deployed bundle)
- `frontend/scripts/prerender.mjs` — build-time tooling (build hygiene fix; never runs in production)

The AuthContext fix is the load-bearing one for production. The prerender script fix only quiets misleading build-log noise.

## Test plan

- [x] `npm run build` clean: 0 occurrences of "error.*418" or "error.*423"
- [x] All 12 routes still bake successfully; `/changelog` postcondition still passes (50 TechArticle items)
- [x] Spot-check baked HTML: `/`, `/privacy`, `/compare/visualping-alternative` all contain real `<h1>` content, BreadcrumbList JSON-LD intact
- [x] Nav on /privacy bakes the unauthenticated `Sign in` cluster (matches runtime first paint)
- [x] `npm run lint` clean (only pre-existing WatchList warning)
- [ ] Post-merge: dev mode (`npm run dev` → http://localhost:5173) confirms unauthenticated marketing routes render without console hydration warnings, and authenticated routes (`/dashboard` etc.) still load Clerk and gate properly. Authenticated Nav cluster (Dashboard link) still appears once Clerk resolves.