### PR TITLE
fix(docs): point robots.txt sitemap at docs.webwhen.ai (#seo-preflight A)

### DIFF
--- a/docs-site/public/robots.txt
+++ b/docs-site/public/robots.txt
@@ -1,5 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://docs.torale.ai/sitemap.xml
-Sitemap: https://torale.ai/sitemap.xml
+Sitemap: https://docs.webwhen.ai/sitemap.xml


### PR DESCRIPTION
## Summary

Closes part of the SEO preflight audit (#seo-preflight). docs-site's robots.txt referenced two stale sitemap URLs on the old `torale.ai` zone:

- `https://docs.torale.ai/sitemap.xml`
- `https://torale.ai/sitemap.xml`

Replaced with the single canonical `https://docs.webwhen.ai/sitemap.xml`. The torale.ai zone records have been retired (post-#281) and the apex/docs subdomains 301-redirect to webwhen.ai counterparts now, so the old URLs would have served redirects to crawlers — confusing.

webwhen.ai's main sitemap is referenced separately in `frontend/public/robots.txt`; this PR is docs-only.

## Test plan

- [x] Diff shows 2 lines removed, 1 added
- [ ] Post-merge: `curl https://docs.webwhen.ai/robots.txt` returns the new single sitemap line