### PR TITLE
docs: flip torale.ai → webwhen.ai in user-facing prose + samples (#seo-preflight B)

### DIFF
--- a/docs-site/api/authentication.md
+++ b/docs-site/api/authentication.md
@@ -22,7 +22,7 @@ Used for browser-based authentication in the web dashboard.
 - Email + password
 
 **How it works:**
-1. User logs in via Clerk at torale.ai
+1. User logs in via Clerk at webwhen.ai
 2. Clerk issues a JWT
 3. The frontend includes the token in API requests
 4. The backend verifies the token with Clerk
@@ -51,7 +51,7 @@ Example: sk_abc123def456ghi789jkl012mno345pq
 
 ### Web dashboard
 
-1. **Log in** to [torale.ai](https://torale.ai)
+1. **Log in** to [webwhen.ai](https://webwhen.ai)
 2. **Navigate** to Settings → API Keys
 3. **Click** "Generate New Key"
 4. **Enter** a key name (for example, "My API Key", "Production Script")
@@ -76,7 +76,7 @@ Example: sk_abc123def456ghi789jkl012mno345pq
 
 **Include in the `Authorization` header:**
 ```bash
-curl -X GET https://api.torale.ai/api/v1/tasks \
+curl -X GET https://api.webwhen.ai/api/v1/tasks \
   -H "Authorization: Bearer sk_..."
 ```
 
@@ -84,7 +84,7 @@ curl -X GET https://api.torale.ai/api/v1/tasks \
 ```bash
 API_KEY="sk_..."
 
-curl -X POST https://api.torale.ai/api/v1/tasks \
+curl -X POST https://api.webwhen.ai/api/v1/tasks \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs-site/api/errors.md
+++ b/docs-site/api/errors.md
@@ -241,7 +241,7 @@ Returned when an external dependency (such as Clerk) is unavailable.
 
 ```bash
 # Verbose curl output shows status code and headers
-curl -v -X GET https://api.torale.ai/api/v1/tasks \
+curl -v -X GET https://api.webwhen.ai/api/v1/tasks \
   -H "Authorization: Bearer sk_..."
 ```
 

--- a/docs-site/api/executions.md
+++ b/docs-site/api/executions.md
@@ -12,7 +12,7 @@ URLs still address watches as `tasks` (`/api/v1/tasks/{task_id}/executions`). Th
 
 ## Overview
 
-Base URL: `https://api.torale.ai/api/v1/tasks/{task_id}/executions`
+Base URL: `https://api.webwhen.ai/api/v1/tasks/{task_id}/executions`
 
 Supports both authenticated and unauthenticated access (for public watches).
 
@@ -61,11 +61,11 @@ Get every execution for a specific watch. Returns a bare JSON array (no paginati
 **Examples:**
 ```bash
 # Get all executions (up to 100)
-curl -X GET https://api.torale.ai/api/v1/tasks/550e8400.../executions \
+curl -X GET https://api.webwhen.ai/api/v1/tasks/550e8400.../executions \
   -H "Authorization: Bearer sk_..."
 
 # Limit results
-curl -X GET "https://api.torale.ai/api/v1/tasks/550e8400.../executions?limit=10" \
+curl -X GET "https://api.webwhen.ai/api/v1/tasks/550e8400.../executions?limit=10" \
   -H "Authorization: Bearer sk_..."
 ```
 

--- a/docs-site/api/index.md
+++ b/docs-site/api/index.md
@@ -7,7 +7,7 @@ description: webwhen REST API reference. HTTP endpoints, authentication, request
 Direct HTTP API access for the webwhen platform.
 
 ::: tip Naming during the transition
-The API host is still `api.torale.ai` and watches are still addressed as `tasks` in URLs (`/api/v1/tasks`). The rename to `webwhen` is a later phase — endpoint paths below reflect the current shipping API.
+The API host is `api.webwhen.ai` (`api.torale.ai` still 301-redirects for legacy clients). Watches are addressed as `tasks` in URLs (`/api/v1/tasks`) — the resource rename is a later phase. Endpoint paths below reflect the current shipping API.
 :::
 
 ## Getting started
@@ -32,8 +32,8 @@ The API host is still `api.torale.ai` and watches are still addressed as `tasks`
 
 webwhen ships interactive API documentation at:
 
-- ReDoc: `https://api.torale.ai/redoc`
-- OpenAPI JSON: `https://api.torale.ai/openapi.json`
+- ReDoc: `https://api.webwhen.ai/redoc`
+- OpenAPI JSON: `https://api.webwhen.ai/openapi.json`
 
 Note: admin endpoints are intentionally hidden from the OpenAPI schema.
 

--- a/docs-site/api/notifications.md
+++ b/docs-site/api/notifications.md
@@ -63,19 +63,19 @@ Authorization: Bearer {api_key}
 **Examples:**
 ```bash
 # Get all notification sends
-curl -X GET https://api.torale.ai/api/v1/notifications/sends \
+curl -X GET https://api.webwhen.ai/api/v1/notifications/sends \
   -H "Authorization: Bearer sk_..."
 
 # Filter by type
-curl -X GET "https://api.torale.ai/api/v1/notifications/sends?notification_type=webhook" \
+curl -X GET "https://api.webwhen.ai/api/v1/notifications/sends?notification_type=webhook" \
   -H "Authorization: Bearer sk_..."
 
 # Filter by watch
-curl -X GET "https://api.torale.ai/api/v1/notifications/sends?task_id=660e8400..." \
+curl -X GET "https://api.webwhen.ai/api/v1/notifications/sends?task_id=660e8400..." \
   -H "Authorization: Bearer sk_..."
 
 # Paginate
-curl -X GET "https://api.torale.ai/api/v1/notifications/sends?limit=10&offset=20" \
+curl -X GET "https://api.webwhen.ai/api/v1/notifications/sends?limit=10&offset=20" \
   -H "Authorization: Bearer sk_..."
 ```
 

--- a/docs-site/api/overview.md
+++ b/docs-site/api/overview.md
@@ -7,21 +7,21 @@ description: webwhen REST API overview. HTTP endpoints, authentication, request 
 webwhen exposes a REST API for programmatic access to every platform feature.
 
 ::: tip Naming during the transition
-The host is still `api.torale.ai` and watches are addressed as `tasks` in URLs (`/api/v1/tasks`). The rename to `webwhen` is a later phase — endpoint paths below reflect the current shipping API.
+The API host is `api.webwhen.ai` (`api.torale.ai` still 301-redirects for legacy clients). Watches are addressed as `tasks` in URLs (`/api/v1/tasks`) — the resource rename is a later phase. Endpoint paths below reflect the current shipping API.
 :::
 
 ## Base URL
 
 ```
-https://api.torale.ai
+https://api.webwhen.ai
 ```
 
 ## Interactive API documentation
 
 For interactive API exploration with detailed request and response schemas:
 
-- [OpenAPI Documentation (ReDoc)](https://api.torale.ai/redoc) — full API reference with schemas
-- [OpenAPI Specification (JSON)](https://api.torale.ai/openapi.json) — machine-readable spec
+- [OpenAPI Documentation (ReDoc)](https://api.webwhen.ai/redoc) — full API reference with schemas
+- [OpenAPI Specification (JSON)](https://api.webwhen.ai/openapi.json) — machine-readable spec
 
 ::: tip Try it out
 The ReDoc interface provides detailed examples and schema information for every endpoint.
@@ -33,10 +33,10 @@ All authenticated requests need an API key or Clerk JWT in the `Authorization` h
 
 ```bash
 curl -H "Authorization: Bearer sk_..." \
-  https://api.torale.ai/api/v1/tasks
+  https://api.webwhen.ai/api/v1/tasks
 ```
 
-Generate API keys at [torale.ai/settings/api-keys](https://torale.ai/settings/api-keys).
+Generate API keys at [webwhen.ai/settings/api-keys](https://webwhen.ai/settings/api-keys).
 
 ## Core endpoints
 

--- a/docs-site/api/tasks.md
+++ b/docs-site/api/tasks.md
@@ -12,7 +12,7 @@ URLs still address watches as `tasks` (`/api/v1/tasks`) and the JSON payloads st
 
 ## Overview
 
-Base URL: `https://api.torale.ai/api/v1/tasks`
+Base URL: `https://api.webwhen.ai/api/v1/tasks`
 
 Every endpoint requires authentication via API key or Clerk JWT unless noted otherwise.
 
@@ -84,7 +84,7 @@ Content-Type: application/json
 
 **Example:**
 ```bash
-curl -X POST https://api.torale.ai/api/v1/tasks \
+curl -X POST https://api.webwhen.ai/api/v1/tasks \
   -H "Authorization: Bearer sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -139,11 +139,11 @@ Authorization: Bearer {api_key}
 **Examples:**
 ```bash
 # Get all watches
-curl -X GET https://api.torale.ai/api/v1/tasks \
+curl -X GET https://api.webwhen.ai/api/v1/tasks \
   -H "Authorization: Bearer sk_..."
 
 # Get only active watches
-curl -X GET "https://api.torale.ai/api/v1/tasks?state=active" \
+curl -X GET "https://api.webwhen.ai/api/v1/tasks?state=active" \
   -H "Authorization: Bearer sk_..."
 ```
 

--- a/docs-site/getting-started/sdk.md
+++ b/docs-site/getting-started/sdk.md
@@ -18,7 +18,7 @@ pip install torale
 
 ## Get an API key
 
-1. Log in to [torale.ai](https://torale.ai)
+1. Log in to [webwhen.ai](https://webwhen.ai)
 2. Go to Settings → API Keys
 3. Generate a new key
 4. Copy and save it securely

--- a/docs-site/integrations/openclaw.md
+++ b/docs-site/integrations/openclaw.md
@@ -7,7 +7,7 @@ description: Integrate webwhen with OpenClaw to add web watching to your AI assi
 Use webwhen as a web-watching backend for [OpenClaw](https://openclaw.ai). webwhen watches for conditions on the web; OpenClaw acts when they're met.
 
 ::: tip Naming during the transition
-The API host is still `api.torale.ai` and watches are still addressed as `tasks` in URLs. The rename to `webwhen` is a later phase — endpoint paths below reflect the current shipping API.
+The API host is `api.webwhen.ai` (`api.torale.ai` still 301-redirects for legacy clients). Watches are still addressed as `tasks` in URLs — the resource rename is a later phase. Endpoint paths below reflect the current shipping API.
 :::
 
 ## How it works
@@ -77,12 +77,12 @@ OpenClaw creates the watch and webwhen handles the rest.
 
 ## API reference
 
-All requests go to `https://api.torale.ai/api/v1` with `Authorization: Bearer sk_...`.
+All requests go to `https://api.webwhen.ai/api/v1` with `Authorization: Bearer sk_...`.
 
 ### Create a watch
 
 ```bash
-curl -X POST https://api.torale.ai/api/v1/tasks \
+curl -X POST https://api.webwhen.ai/api/v1/tasks \
   -H "Authorization: Bearer sk_..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -104,14 +104,14 @@ curl -X POST https://api.torale.ai/api/v1/tasks \
 ### List watches
 
 ```bash
-curl https://api.torale.ai/api/v1/tasks \
+curl https://api.webwhen.ai/api/v1/tasks \
   -H "Authorization: Bearer sk_..."
 ```
 
 ### Delete a watch
 
 ```bash
-curl -X DELETE https://api.torale.ai/api/v1/tasks/{task_id} \
+curl -X DELETE https://api.webwhen.ai/api/v1/tasks/{task_id} \
   -H "Authorization: Bearer sk_..."
 ```
 

--- a/docs-site/sdk/authentication.md
+++ b/docs-site/sdk/authentication.md
@@ -12,7 +12,7 @@ Environment variable names and the client class still use `torale` (`TORALE_API_
 
 ## Get an API key
 
-1. Log in to [torale.ai](https://torale.ai)
+1. Log in to [webwhen.ai](https://webwhen.ai)
 2. Navigate to Settings → API Keys
 3. Generate a new key
 4. Copy and save it securely
@@ -68,7 +68,7 @@ The SDK reads from `~/.torale/config.json` if it exists:
 ```json
 {
   "api_key": "sk_...",
-  "api_url": "https://api.torale.ai"
+  "api_url": "https://api.webwhen.ai"
 }
 ```
 
@@ -102,7 +102,7 @@ The base URL is resolved in this order:
 2. `TORALE_API_URL` environment variable
 3. `http://localhost:8000` if `TORALE_DEV=1` or `TORALE_NOAUTH=1`
 4. `api_url` from `~/.torale/config.json`
-5. `https://api.torale.ai` (default)
+5. `https://api.webwhen.ai` (default)
 
 ## Error handling
 

--- a/docs-site/sdk/quickstart.md
+++ b/docs-site/sdk/quickstart.md
@@ -18,7 +18,7 @@ pip install torale
 
 ## Get an API key
 
-1. Log in to [torale.ai](https://torale.ai)
+1. Log in to [webwhen.ai](https://webwhen.ai)
 2. Navigate to Settings → API Keys
 3. Generate a new key
 4. Copy the key (shown only once)


### PR DESCRIPTION
## Summary

Closes part of the SEO preflight audit (#seo-preflight). Flips user-facing `torale.ai` references in docs prose and code samples to `webwhen.ai`. The redirects 301 either way, but the docs were instructing readers to use the old domain — confusing post-cutover.

Per orchestrator's nuance on prose ("If it's *describing the redirect for legacy SDK users*, keep it but reword"; "If it's *instructing readers*, flip outright"), each line was reviewed individually rather than sed-replaced blindly.

## Per-file decisions

### `docs-site/integrations/openclaw.md`
- **Line 10 (prose)**: Was outdated ("The API host is **still** api.torale.ai..."). Reworded to current state with legacy-redirect callout: "The API host is `api.webwhen.ai` (`api.torale.ai` still 301-redirects for legacy clients)."
- **Lines 80, 85, 107, 114 (code samples)**: `https://api.torale.ai` → `https://api.webwhen.ai` outright. These are tutorial-style instructions, no reason to teach the old URL.

### `docs-site/api/index.md` and `docs-site/api/overview.md`
- **Line 10 (prose)**: Same pattern as openclaw — reworded with legacy-redirect callout. Removed the now-contradictory "The rename to webwhen is a later phase" sentence (the URL rename HAS happened; only the resource name `tasks` rename is still later).
- **All other lines**: Code samples + URL listings (ReDoc, OpenAPI JSON, /settings/api-keys link). All flipped to webwhen.ai outright.

### `docs-site/api/{notifications,errors,tasks,executions,authentication}.md`, `docs-site/sdk/{quickstart,authentication}.md`, `docs-site/getting-started/sdk.md`
- **All instances**: instructional code samples or "Log in to [torale.ai]" prose. Flipped to webwhen.ai outright.

## What's KEPT as-is

- **`docs-site/.vitepress/config.ts:4-6`**: comments documenting the rebrand-time decision (intentional history reference, not user-visible).
- **`docs-site/public/robots.txt`**: stale sitemap URLs handled in PR A (#320).
- **`backend/src/torale/...` paths in code-comment-style references** elsewhere in repo: internal pointers, not in scope for SEO.

Three remaining `torale.ai` strings in `docs-site/` are intentional — all three are the new "(api.torale.ai still 301-redirects for legacy clients)" parenthetical added in this PR.

## Diff

`git diff --stat`:
```
 docs-site/api/authentication.md    |  8 ++++----
 docs-site/api/errors.md            |  2 +-
 docs-site/api/executions.md        |  6 +++---
 docs-site/api/index.md             |  6 +++---
 docs-site/api/notifications.md     |  8 ++++----
 docs-site/api/overview.md          | 12 ++++++------
 docs-site/api/tasks.md             |  8 ++++----
 docs-site/getting-started/sdk.md   |  2 +-
 docs-site/integrations/openclaw.md | 10 +++++-----
 docs-site/sdk/authentication.md    |  6 +++---
 docs-site/sdk/quickstart.md        |  2 +-
 11 files changed, 35 insertions(+), 35 deletions(-)
```

## Test plan

- [x] Final whole-`docs-site/` grep: only the 3 intentional legacy-redirect callouts remain
- [ ] Post-merge: spot-check `https://docs.webwhen.ai/api/overview` rendered HTML shows `api.webwhen.ai` not `api.torale.ai`
- [ ] Verify the `[webwhen.ai/settings/api-keys](https://webwhen.ai/settings/api-keys)` link target resolves (the path exists on webwhen.ai for authenticated users; should 200 from edge or redirect to sign-in)

## Coverage note

Original audit checklist enumerated 5 files; whole-`docs-site/` grep surfaced 11 (api/notifications, api/tasks, api/index, api/overview, api/errors, api/executions also affected). Probe-at-caller-layer discipline applied — fuller sweep is in this PR rather than punting another follow-up.