### PR TITLE
fix(connectors): rebrand toast string Torale → webwhen (#seo-preflight C)

### DIFF
--- a/frontend/src/components/connectors/ReconnectButton.tsx
+++ b/frontend/src/components/connectors/ReconnectButton.tsx
@@ -36,7 +36,7 @@ export const ReconnectButton: React.FC<ReconnectButtonProps> = ({
         popup.location.href = redirect_url;
         popup.opener = null;
       } else {
-        toast.error('Popup blocked. Allow popups for Torale and try again.');
+        toast.error('Popup blocked. Allow popups for webwhen and try again.');
       }
     } catch (err) {
       if (popup) popup.close();


### PR DESCRIPTION
## Summary

Closes part of the SEO preflight audit (#seo-preflight). One stale "Torale" string in a user-visible toast message, surfaced when popup-blocker prevents Composio OAuth reconnect:

```diff
-toast.error('Popup blocked. Allow popups for Torale and try again.');
+toast.error('Popup blocked. Allow popups for webwhen and try again.');
```

Path: `frontend/src/components/connectors/ReconnectButton.tsx:39`. Triggered when a user clicks "Reconnect" on a Composio connector (Notion, Linear, GitHub) and the browser blocks the OAuth popup. The message is the user's instruction for resolving the block.

## Test plan

- [x] One-line text change, no logic touched
- [ ] Post-merge: spot-check the toast renders with "webwhen" if a popup-blocked reconnect path is exercised in dev