### PR TITLE
fix(docs): repoint og:image to webwhen.ai/og-image.webp (#seo-preflight D)

### DIFF
--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -49,11 +49,15 @@ export default withMermaid(
     ['meta', { name: 'theme-color', content: '#0B0B0C' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:site_name', content: 'webwhen docs' }],
-    ['meta', { property: 'og:image', content: `${SITE_ORIGIN}/og-image.png` }],
+    // Reuse the webwhen.ai OG image for docs social cards. docs-site has no
+    // og-image asset of its own (and the previous `${SITE_ORIGIN}/og-image.png`
+    // 404'd, breaking social card scrapers). Cross-origin OG images are fine —
+    // all major crawlers fetch them. See #seo-preflight.
+    ['meta', { property: 'og:image', content: 'https://webwhen.ai/og-image.webp' }],
     ['meta', { property: 'og:image:width', content: '1200' }],
     ['meta', { property: 'og:image:height', content: '630' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
-    ['meta', { name: 'twitter:image', content: `${SITE_ORIGIN}/og-image.png` }],
+    ['meta', { name: 'twitter:image', content: 'https://webwhen.ai/og-image.webp' }],
   ],
 
   // Per-page meta has to land in static HTML — VitePress sets it client-side


### PR DESCRIPTION
## Summary

Closes part of the SEO preflight audit (#seo-preflight). docs.webwhen.ai's og:image and twitter:image meta tags pointed at `https://docs.webwhen.ai/og-image.png`, but that asset doesn't exist (returns 404). Social card scrapers — Twitter/LinkedIn/Slack unfurls, Facebook share previews, etc. — would have hit a 404 on every shared docs link.

Per orchestrator's call: don't create a new PNG asset; reuse the existing `https://webwhen.ai/og-image.webp` cross-origin. Cross-origin OG images are supported by all major crawlers (Twitter card validator, Facebook debugger, etc. all dereference whatever `og:image` URL is given).

Verified `https://webwhen.ai/og-image.webp` returns 200, 1200×630, 53KB webp — exactly what docs needs.

## Changes

`docs-site/.vitepress/config.ts`:
- `og:image` and `twitter:image` content flipped from `${SITE_ORIGIN}/og-image.png` (404) to `https://webwhen.ai/og-image.webp` (200)
- Added a comment explaining the cross-origin reuse so future contributors don't see a hardcoded webwhen URL and "fix" it.
- `og:image:width` and `og:image:height` (1200, 630) preserved — the webp is the same dimensions the prior PNG would have been.

## Test plan

- [x] `webwhen.ai/og-image.webp` returns 200, 1200×630, image/webp, ~53KB
- [ ] Post-merge: `curl https://docs.webwhen.ai/ | grep og:image` should show the webwhen.ai URL.
- [ ] Twitter card validator (https://cards-dev.twitter.com/validator) on https://docs.webwhen.ai/ should render the card with image.