### PR TITLE
fix(seo): align html lang to en-US matching docs zone (#seo-preflight E)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en-US">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/brand/webwhen-mark-favicon.svg" />


### PR DESCRIPTION
## Summary

Closes part of the SEO preflight audit (#seo-preflight). Surfaced via orchestrator's "add #1" check on `<html lang>` consistency across both zones.

**Before**:
- `https://webwhen.ai/*` (every prerendered + SPA-shell-served route): `<html lang="en">`
- `https://docs.webwhen.ai/*`: `<html lang="en-US">`

GSC flags inconsistent `lang` declarations across the same site as a hreflang/i18n signal mismatch — the search engine isn't sure whether `webwhen.ai` is generic-English content while `docs.webwhen.ai` is US-specific, or whether the team simply forgot to set the locale on one of them.

**After**: both zones declare `<html lang="en-US">`. en-US is the more specific tag and what docs already declared; promoting webwhen.ai to match is one line.

## Source

`frontend/index.html` is the SPA shell that bakes into every prerendered route's HTML during `npm run build`. So this single line propagates to all 12 prerendered routes plus any SPA-served path.

## Test plan

- [x] One-line text change in `frontend/index.html`
- [ ] Post-merge: `curl https://webwhen.ai/ | grep -oE '<html[^>]*'` → should show `<html lang="en-US"`
- [ ] Cross-zone consistency check: same grep on `/privacy`, `/changelog`, `/compare/visualping-alternative`, `/use-cases/steam-game-price-alerts`, plus `https://docs.webwhen.ai/` and `https://docs.webwhen.ai/getting-started` — all should report `en-US`.