### PR TITLE
fix(seo): align robots.txt Disallow with hyphenated SPA routes (#seo-verify F)

### DIFF
--- a/backend/src/torale/api/routers/sitemap.py
+++ b/backend/src/torale/api/routers/sitemap.py
@@ -230,6 +230,12 @@ async def robots_txt():
     if base_url not in PROD_FRONTEND_URLS:
         return Response(content="User-agent: *\nDisallow: /\n", media_type="text/plain")
 
+    # Disallow covers both live hyphenated routes (/sign-in, /sign-up) and
+    # the legacy un-hyphenated forms (/signin, /signup) so historical inbound
+    # links remain covered. /admin and /admin/ both listed because /admin/
+    # only matches /admin/foo, not /admin exact. /dashboard and /welcome
+    # added — auth-gated SPA routes that should not be indexed. /tasks/
+    # stays Allow (covers public task pages in sitemap-dynamic).
     robots = f"""User-agent: *
 Allow: /
 Allow: /explore
@@ -238,9 +244,14 @@ Allow: /tasks/
 Disallow: /api/
 Disallow: /auth/
 Disallow: /signin
+Disallow: /sign-in
 Disallow: /signup
+Disallow: /sign-up
 Disallow: /settings
+Disallow: /admin
 Disallow: /admin/
+Disallow: /dashboard
+Disallow: /welcome
 
 Sitemap: {base_url}/sitemap.xml
 """


### PR DESCRIPTION
## Summary

Closes part of the SEO verify pass (#seo-verify). webwhen.ai/robots.txt was constructed against guesses at the SPA routes; live URLs are hyphenated and several auth-gated paths were missing.

**Before**:
```
Disallow: /api/
Disallow: /auth/
Disallow: /signin
Disallow: /signup
Disallow: /settings
Disallow: /admin/
```

**After**:
```
Disallow: /api/
Disallow: /auth/
Disallow: /signin
Disallow: /sign-in
Disallow: /signup
Disallow: /sign-up
Disallow: /settings
Disallow: /admin
Disallow: /admin/
Disallow: /dashboard
Disallow: /welcome
```

### Why each addition

- `/sign-in`, `/sign-up` (hyphenated): the actual live URLs per `App.tsx` Routes. Without these crawlers were free to crawl auth-wall pages.
- `/signin`, `/signup` retained: harmless coverage for any historical inbound links typed in the un-hyphenated form.
- `/admin` (no trailing slash): `/admin/` only catches `/admin/foo`; `/admin` exact was uncovered.
- `/dashboard`, `/welcome`: auth-gated SPA routes that render the SPA shell to non-authenticated visitors and shouldn't be indexed.
- `/admin/` retained: still useful for `/admin/users`, `/admin/tasks` etc.
- `/tasks/` stays Allow because public task pages are indexable (sitemap-dynamic.xml lists them).

## Surface

`backend/src/torale/api/routers/sitemap.py:233-246` — backend-served, hits `https://webwhen.ai/robots.txt` via the HTTPRoute on the api backend (the frontend nginx routes `/robots.txt` to backend per the existing httproute config).

Non-prod hosts (staging, dev) still return the blanket `Disallow: /` per the existing branch on line 230 — unchanged.

## Test plan

- [x] `uv run pytest backend/tests/ -k "robots or sitemap"` — 0 tests deselected from 257, 0 failures (no robots-specific tests exist; sitemap tests still pass).
- [ ] Post-merge: `curl https://webwhen.ai/robots.txt` shows the new 11-entry Disallow list.
- [ ] Edge cache: needs CF purge on `/robots.txt` (will dispatch with merge).