### PR TITLE
fix(seo): 301 redirect .html-extension forms to canonical (#328)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -46,6 +46,28 @@ server {
 
     rewrite ^/(.+)/$ /$1 permanent;
 
+    # Strip .html from external URLs so the canonical no-extension form is
+    # the only reachable URL. Client request `/changelog.html` → 301 →
+    # `/changelog`. Server-scope rewrite fires BEFORE location selection on
+    # incoming requests; the `try_files $uri.html` candidate inside
+    # `location /` (line ~70) is an internal rewrite that does NOT re-enter
+    # the rewrite phase, so the prerendered HTML is still served correctly
+    # under the clean URL.
+    #
+    # Excludes `/index.html` exact: the SPA shell entry point is served by
+    # `location = /index.html` further down. Without the exclusion, a 301 →
+    # `/index` would break the SPA.
+    #
+    # See #328.
+    #
+    # The `(?!index\.html$)` negative lookahead protects `/index.html` exact
+    # — that's the SPA shell, served by `location = /index.html` below. A
+    # nested `/foo/index.html` (none currently exist, but hypothetically) is
+    # NOT excluded; it would redirect to `/foo/index`. That's the desired
+    # behaviour if anyone ever ships such a file: the canonical form is
+    # without the extension.
+    rewrite ^/(?!index\.html$)(.+)\.html$ /$1 permanent;
+
     # /sitemap.xml and /robots.txt are routed to the backend by the Gateway
     # HTTPRoute (see helm/torale/templates/httproute.yaml). The backend serves
     # a sitemap index that points at /sitemap-static.xml (this nginx) and


### PR DESCRIPTION
## Summary

Closes #328. Adds a server-scope `rewrite` so `/changelog.html`, `/privacy.html`, `/compare/visualping-alternative.html`, etc. 301-redirect to their canonical (no-extension) form, instead of returning 200 with duplicate content.

## Why

Pre-existing soft-gap: `frontend/nginx.conf:70` has `try_files $uri $uri.html @spa_shell` to serve prerendered route HTML under clean URLs (e.g. request `/changelog`, nginx serves `dist/changelog.html` internally with status 200). But the same try_files rule means an EXPLICIT `/changelog.html` client request also matches `$uri` (the file exists on disk) and gets served with 200 — two reachable URLs for every prerendered route. Canonical link tags mitigated SERP-consolidation impact, but Bing/Yandex are less canonical-aware and the original #223 expectation was 301.

## Fix

One-line server-scope rewrite, placed alongside the existing trailing-slash rewrite:

```nginx
rewrite ^/(?!index\.html$)(.+)\.html$ /$1 permanent;
```

- Server-scope rewrite fires BEFORE location selection on incoming HTTP requests, so it catches client URLs.
- The `try_files $uri.html` candidate inside `location /` is an INTERNAL nginx rewrite that does NOT re-enter the rewrite phase, so prerendered HTML still serves correctly under the clean URL.
- Negative lookahead `(?!index\.html$)` excludes `/index.html` exact (the SPA shell entry point served by `location = /index.html`). Without the exclusion, a 301 → `/index` would break the SPA bootstrap.

## Test matrix (live nginx, real config + fake dist)

Built with `docker run nginx:alpine` against the project's nginx.conf (with `more_set_headers` lines neutered for stock-nginx syntax test, since the project compiles headers-more in the production image — no functional impact on the routing logic being tested):

```
/                                           → 200 (SPA shell)
/changelog                                  → 200 (serves CHANGELOG PRERENDERED content)
/changelog.html                             → 301 → /changelog ✓
/privacy                                    → 200 (serves PRIVACY PRERENDERED)
/privacy.html                               → 301 → /privacy ✓
/compare/visualping-alternative             → 200
/compare/visualping-alternative.html        → 301 → /compare/visualping-alternative ✓
/use-cases/steam-game-price-alerts.html     → 301 → /use-cases/steam-game-price-alerts ✓
/concepts/self-scheduling-agents.html       → 301 → /concepts/self-scheduling-agents ✓
/index.html                                 → 200 (correctly excluded by negative lookahead)
/this-page-does-not-exist                   → 200 (SPA shell fallback, expected)
/this-page-does-not-exist.html              → 301 → /this-page-does-not-exist (then SPA shell, no loop)
```

GET on `/changelog` returns the prerendered HTML body (verified content), not the SPA shell — proving the internal `try_files $uri.html` continues to work after the rewrite addition.

## Test plan

- [x] `docker run nginx:alpine -v <conf>:<conf>:ro nginx -t` syntax-validates clean (with more_set_headers commented for stock-nginx test).
- [x] Full route matrix tested in a live nginx container with a fake dist mirror — see table above. All 12-pattern combinations verified.
- [x] `/index.html` exclusion confirmed (would break SPA otherwise).
- [x] No internal-rewrite loop on `try_files $uri.html` candidate.
- [ ] Post-merge smoke T+5min: hit each of the 12 prerendered routes both ways (clean form → 200, .html form → 301 → clean form) from edge AND origin.
- [ ] CF purge on the .html paths post-deploy (defensive — they may have been cached as 200 from the prior 7-PR sweep).

## Related

- #310 (SPA 404 Option B) shares nginx route topology; the issue body recommends bundling but this is a small targeted fix shippable on its own.
- #223 referenced this expectation but the 301 was apparently never deployed or got reverted somewhere. Now actually shipped.