### PR TITLE
fix(connectors): rebrand 4 user-visible Torale strings → webwhen (#composio-functional-check H)

### DIFF
--- a/backend/src/torale/api/routers/connectors.py
+++ b/backend/src/torale/api/routers/connectors.py
@@ -305,7 +305,7 @@ async def disconnect_toolkit(
 
 
 _CALLBACK_HTML = """<!doctype html>
-<html lang="en">
+<html lang="en-US">
 <head>
 <meta charset="utf-8">
 <title>Connection complete</title>
@@ -333,14 +333,14 @@ _CALLBACK_FAILED_HTML = _CALLBACK_HTML.format(
     status_class="failed",
     border_color="#ef4444",
     title="Connection failed",
-    body="Something went wrong. Close this tab and try again from Torale.",
+    body="Something went wrong. Close this tab and try again from webwhen.",
 )
 
 _CALLBACK_SUCCESS_HTML = _CALLBACK_HTML.format(
     status_class="success",
     border_color="#10b981",
     title="Connection complete",
-    body="You can close this tab and return to Torale.",
+    body="You can close this tab and return to webwhen.",
 )
 
 

--- a/frontend/src/pages/ConnectorsPage.tsx
+++ b/frontend/src/pages/ConnectorsPage.tsx
@@ -156,7 +156,7 @@ export const ConnectorsPage: React.FC = () => {
         Connections powered by Composio — you'll see their name on the
         authorization screen.{' '}
         <a
-          href="https://docs.torale.ai/architecture/connectors-trust"
+          href="https://docs.webwhen.ai/architecture/connectors-trust"
           target="_blank"
           rel="noopener noreferrer"
           className={styles.helperLink}


### PR DESCRIPTION
## Summary

Closes the user-visible Torale strings in the Composio connector flow surfaced by the post-rebrand functional check (#composio-functional-check). Four line changes across two files. No code-path changes; same root cause as the prior post-rebrand string sweeps.

## Changes

### Backend OAuth callback HTML (`backend/src/torale/api/routers/connectors.py`)

The Composio OAuth completion popup is shown to every user after every successful connector connect (and on the failure variant on auth failure). Three Torale strings flipped:

- **Line 308**: `<html lang="en">` → `<html lang="en-US">` (consistency with the site-wide en-US established in #324)
- **Line 336** (failed body): `"Something went wrong. Close this tab and try again from Torale."` → `webwhen`
- **Line 343** (success body): `"You can close this tab and return to Torale."` → `webwhen`

Per Prass's prose-review pattern: "return to webwhen" reads naturally lowercase as the brand. Same for "try again from webwhen".

### Frontend connector trust link (`frontend/src/pages/ConnectorsPage.tsx`)

- **Line 159**: `href="https://docs.torale.ai/architecture/connectors-trust"` → `https://docs.webwhen.ai/architecture/connectors-trust`. The `docs.torale.ai` 301-redirects to webwhen, so the link worked, but the user-facing href shouldn't carry the old brand.

## What's NOT in this PR

- Composio SDK 0.11.5 → 0.12.0 bump — separate decision, file as issue if desired (composio ships breaking changes regularly).
- Webhook implementation — deliberate polling-not-webhooks design, separate decision.
- #226 connector branded icons — P3 polish, out of scope.

## Test plan

- [x] `uv run pytest tests/ -k "connector or callback"` clean (no connector tests exist; 257 deselected, 0 failures)
- [x] `npm run lint` clean (only pre-existing WatchList warning)
- [x] grep verifies all 4 strings flipped, zero `[Tt]orale` user-visible leftovers in callback HTML or ConnectorsPage trust link
- [ ] Post-merge edge: trigger a stub callback like `curl 'https://api.webwhen.ai/api/v1/connectors/callback?user_id=...&status=...&connectedAccountId=...&appName=notion'` and confirm the rendered HTML body contains "return to webwhen" / `lang="en-US"`.
- [ ] Post-merge: load `/settings/connectors` in dev with VITE_TORALE_NOAUTH=1 and verify "Privacy & security" link points to `docs.webwhen.ai`.
- [ ] Origin spot-check: `kubectl exec deploy/torale-api -- /bin/grep -c 'return to webwhen' /app/src/torale/api/routers/connectors.py` should return 1.

## Coverage note

Whole-repo grep before-during-after this PR confirms zero remaining `[Tt]orale\.ai` strings in `frontend/src/components/connectors/` or `backend/src/torale/connectors/`. The only other `[Tt]orale` strings on either surface are the GitHub repo URL (`prassanna-ravishankar/torale`) and the internal `@/components/torale` import alias — both intentional per the rebrand-metadata-decision (#308 outcome).