### PR TITLE
fix(seo): 301 /index.html to / (audit V2 B2)

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -50,23 +50,20 @@ server {
     # the only reachable URL. Client request `/changelog.html` → 301 →
     # `/changelog`. Server-scope rewrite fires BEFORE location selection on
     # incoming requests; the `try_files $uri.html` candidate inside
-    # `location /` (line ~70) is an internal rewrite that does NOT re-enter
-    # the rewrite phase, so the prerendered HTML is still served correctly
-    # under the clean URL.
+    # `location /` is an internal rewrite that does NOT re-enter the rewrite
+    # phase, so the prerendered HTML is still served correctly under the
+    # clean URL.
     #
-    # Excludes `/index.html` exact: the SPA shell entry point is served by
-    # `location = /index.html` further down. Without the exclusion, a 301 →
-    # `/index` would break the SPA.
+    # `/index.html` exact → 301 → `/`. SEO-audit V2 (B2): the previous
+    # negative-lookahead guard left `/index.html` reachable as a 200,
+    # creating a homepage duplicate in Google's index. Internal serving of
+    # the SPA shell is unaffected: the `index index.html;` directive (above)
+    # and the `try_files /index.html =404;` in @spa_shell are internal
+    # nginx lookups that bypass the rewrite phase.
     #
-    # See #328.
-    #
-    # The `(?!index\.html$)` negative lookahead protects `/index.html` exact
-    # — that's the SPA shell, served by `location = /index.html` below. A
-    # nested `/foo/index.html` (none currently exist, but hypothetically) is
-    # NOT excluded; it would redirect to `/foo/index`. That's the desired
-    # behaviour if anyone ever ships such a file: the canonical form is
-    # without the extension.
-    rewrite ^/(?!index\.html$)(.+)\.html$ /$1 permanent;
+    # See #328 (.html sub-paths) and #329 (PR follow-up).
+    rewrite ^/index\.html$ / permanent;
+    rewrite ^/(.+)\.html$ /$1 permanent;
 
     # /sitemap.xml and /robots.txt are routed to the backend by the Gateway
     # HTTPRoute (see helm/torale/templates/httproute.yaml). The backend serves


### PR DESCRIPTION
## Summary

`https://webwhen.ai/index.html` currently returns HTTP 200 with the full home-page HTML. That makes it a duplicate of `/` in Google's index — exactly the duplicate-content trap PR #329 set out to close, with the root path missed.

This extends the `.html` redirect rule to handle the root `/index.html` form too. PR #329 used a negative-lookahead `(?!index\.html$)` to protect SPA bootstrap; this PR replaces it with two ordered rewrites — the specific `/index.html` → `/` rule first, then the general `*.html` → `*` rule.

The internal SPA-shell serving is unaffected: `index index.html;` and `try_files /index.html =404;` are internal lookups that bypass the rewrite phase.

## Smoke (local docker, stub html dir, headers-more lines stripped for vanilla nginx)

| Request | Expected | Actual |
|---|---|---|
| `GET /index.html` | 301 → `/` | 301 → `/` ✓ |
| `GET /` | 200 (SHELL) | 200 (SHELL) ✓ |
| `GET /changelog.html` | 301 → `/changelog` (preserve #329) | 301 → `/changelog` ✓ |
| `GET /changelog` | 200 prerendered | 200 ✓ |
| `GET /explore` | 200 | 200 ✓ |
| `GET /random-unknown-path` | 200 SPA shell (unchanged) | 200 ✓ |
| `GET /index/` (trailing-slash collapse) | 301 → `/index` | 301 → `/index` ✓ |

No infinite loop. No SPA-bootstrap breakage. Internal `try_files /index.html` still resolves.

## Test plan
- [ ] CI green
- [ ] Post-deploy: `curl -sI https://webwhen.ai/index.html` returns 301 with `Location: /`
- [ ] Post-deploy: `curl -sI https://webwhen.ai/` still returns 200 with prerendered HTML
- [ ] Post-deploy: SPA bootstrap still works on `/sign-in`, `/dashboard`, `/sign-up` in a real browser