### PR TITLE
fix(seo): block SEO endpoints on api host (audit V2 B4)

### DIFF
--- a/backend/src/torale/api/routers/sitemap.py
+++ b/backend/src/torale/api/routers/sitemap.py
@@ -5,8 +5,9 @@ import xml.etree.ElementTree as ET
 from datetime import datetime
 from email.utils import format_datetime
 from pathlib import Path
+from urllib.parse import urlparse
 
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
 from torale.core.config import PROJECT_ROOT, settings
 from torale.core.database import Database, get_db
@@ -17,13 +18,39 @@ ET.register_namespace("atom", "http://www.w3.org/2005/Atom")
 router = APIRouter(tags=["seo"])
 
 
+def _is_marketing_host(request: Request) -> bool:
+    """
+    True when the inbound request hits the marketing-zone hostname (the host
+    component of settings.frontend_url).
+
+    The same FastAPI app serves both marketing-routed paths via Gateway
+    HTTPRoute (/sitemap.xml, /robots.txt, /changelog.xml on webwhen.ai) and
+    the API zone (api.webwhen.ai). The k8s HTTPRoute for api.webwhen.ai
+    forwards every path to this app, so /sitemap.xml on the api host would
+    otherwise mirror the marketing sitemap — confusing for crawlers and a
+    cross-host sitemap-declaration anti-pattern. SEO audit V2 (B4).
+
+    Falls back to True when request.url.hostname is unavailable (test client
+    edge cases) so existing tests and unauthenticated localhost dev don't
+    regress.
+    """
+    request_host = request.url.hostname
+    if not request_host:
+        return True
+    marketing_host = urlparse(settings.frontend_url).hostname
+    return request_host == marketing_host
+
+
 @router.get("/sitemap.xml")
-async def generate_sitemap_index(db: Database = Depends(get_db)):
+async def generate_sitemap_index(request: Request, db: Database = Depends(get_db)):
     """
     Sitemap index pointing at the static (frontend-served) and dynamic (backend)
     child sitemaps. Frontend owns enumerated SEO routes (publicRoutes.ts);
     backend owns DB-derived public task pages.
     """
+    if not _is_marketing_host(request):
+        raise HTTPException(status_code=404)
+
     base_url = settings.frontend_url
 
     latest_task_lastmod = await db.fetch_val(
@@ -50,11 +77,14 @@ async def generate_sitemap_index(db: Database = Depends(get_db)):
 
 
 @router.get("/sitemap-dynamic.xml")
-async def generate_sitemap_dynamic(db: Database = Depends(get_db)):
+async def generate_sitemap_dynamic(request: Request, db: Database = Depends(get_db)):
     """
     Dynamic sitemap covering DB-derived public pages: landing, explore, changelog,
     and every public task. Linked from /sitemap.xml (the index).
     """
+    if not _is_marketing_host(request):
+        raise HTTPException(status_code=404)
+
     tasks_query = """
         SELECT t.id, t.updated_at
         FROM tasks t
@@ -141,13 +171,16 @@ async def generate_sitemap_dynamic(db: Database = Depends(get_db)):
 
 
 @router.get("/changelog.xml")
-async def generate_changelog_rss():
+async def generate_changelog_rss(request: Request):
     """
     Generate RSS 2.0 feed for changelog.
 
     Reads changelog.json from frontend/public and converts to RSS format.
     Includes first 50 entries with proper RFC-2822 date formatting.
     """
+    if not _is_marketing_host(request):
+        raise HTTPException(status_code=404)
+
     # Get changelog path from settings (supports both relative and absolute paths)
     changelog_path = Path(settings.changelog_json_path)
     if not changelog_path.is_absolute():
@@ -220,12 +253,16 @@ PROD_FRONTEND_URLS = frozenset({"https://webwhen.ai", "https://torale.ai"})
 
 
 @router.get("/robots.txt")
-async def robots_txt():
+async def robots_txt(request: Request):
     """
-    robots.txt for search engine crawlers. Non-prod hosts return a blanket
-    disallow so staging/preview deployments don't get indexed.
+    robots.txt for search engine crawlers. Non-prod hosts and the API host
+    return a blanket disallow so staging/preview deployments and api.webwhen.ai
+    don't get indexed (api host has no public web pages — see B4).
     """
     base_url = settings.frontend_url
+
+    if not _is_marketing_host(request):
+        return Response(content="User-agent: *\nDisallow: /\n", media_type="text/plain")
 
     if base_url not in PROD_FRONTEND_URLS:
         return Response(content="User-agent: *\nDisallow: /\n", media_type="text/plain")

--- a/backend/tests/test_sitemap_host_discrimination.py
+++ b/backend/tests/test_sitemap_host_discrimination.py
@@ -1,0 +1,66 @@
+"""
+Host-aware behavior for SEO endpoints (audit V2 B4).
+
+The same FastAPI app serves the marketing-zone HTTPRoute (webwhen.ai) and
+the API zone HTTPRoute (api.webwhen.ai). Without host discrimination the
+api host mirrors the marketing sitemap and robots — a cross-host
+sitemap-declaration anti-pattern flagged by SEO_AUDIT_V2.
+
+We test the boundary: marketing host serves SEO content; non-marketing
+hosts get a blanket Disallow (robots) or 404 (sitemap/changelog).
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from torale.api.routers.sitemap import router as sitemap_router
+
+
+@pytest.fixture
+def client_marketing_host():
+    """Client whose Host header matches settings.frontend_url (default: webwhen.ai)."""
+    app = FastAPI()
+    app.include_router(sitemap_router)
+    return TestClient(app, base_url="https://webwhen.ai")
+
+
+@pytest.fixture
+def client_api_host():
+    """Client posing as api.webwhen.ai — same FastAPI app, different host header."""
+    app = FastAPI()
+    app.include_router(sitemap_router)
+    return TestClient(app, base_url="https://api.webwhen.ai")
+
+
+class TestApiHostDoesNotLeakSeoEndpoints:
+    """B4: api.webwhen.ai must not mirror the marketing sitemap/changelog."""
+
+    def test_robots_on_api_host_is_blanket_disallow(self, client_api_host):
+        resp = client_api_host.get("/robots.txt")
+        assert resp.status_code == 200
+        assert resp.text.strip() == "User-agent: *\nDisallow: /"
+
+    def test_sitemap_index_on_api_host_returns_404(self, client_api_host):
+        resp = client_api_host.get("/sitemap.xml")
+        assert resp.status_code == 404
+
+    def test_sitemap_dynamic_on_api_host_returns_404(self, client_api_host):
+        resp = client_api_host.get("/sitemap-dynamic.xml")
+        assert resp.status_code == 404
+
+    def test_changelog_rss_on_api_host_returns_404(self, client_api_host):
+        resp = client_api_host.get("/changelog.xml")
+        assert resp.status_code == 404
+
+
+class TestMarketingHostStillServes:
+    """Regression guard: the marketing host must keep serving SEO endpoints."""
+
+    def test_robots_on_marketing_host_lists_sitemap(self, client_marketing_host):
+        resp = client_marketing_host.get("/robots.txt")
+        assert resp.status_code == 200
+        assert "Sitemap: https://webwhen.ai/sitemap.xml" in resp.text
+        assert "Disallow: /dashboard" in resp.text
+        # The marketing robots is NOT blanket-disallow.
+        assert "Allow: /" in resp.text


### PR DESCRIPTION
## Summary

`api.webwhen.ai/sitemap.xml` currently mirrors the marketing-zone sitemap (it lists `webwhen.ai/sitemap-static.xml` and `webwhen.ai/sitemap-dynamic.xml`). Same for `/robots.txt` and `/changelog.xml`. That's a cross-host sitemap-declaration anti-pattern — Google treats sitemaps as authoritative only for the host that serves them. Worse, it gives crawlers a discoverable surface on a host that has no public web pages.

Root cause: the Gateway HTTPRoute for `api.webwhen.ai` forwards every path to the same FastAPI app that backs `webwhen.ai`. The SEO routers (sitemap, changelog, robots) had no host check, so they happily served the marketing payload on either host.

## Change

`_is_marketing_host(request)` compares `request.url.hostname` against the host of `settings.frontend_url`. Off the marketing host:

- `/robots.txt` → `User-agent: *\nDisallow: /` (200 — not 404, since robots.txt at 200 is the canonical "I exist and you should not crawl me" signal)
- `/sitemap.xml`, `/sitemap-dynamic.xml`, `/changelog.xml` → 404

Marketing host behavior is unchanged.

The check falls back to "marketing" when `request.url.hostname` is unavailable (test-client edge cases) so existing tests that don't set Host don't regress.

## Test plan
- [x] New `test_sitemap_host_discrimination.py` — 5 cases, all green:
  - api host: robots is blanket Disallow
  - api host: sitemap.xml / sitemap-dynamic.xml / changelog.xml all 404
  - marketing host: robots still lists sitemap and Disallow rules
- [x] Full backend pytest: `232 passed, 30 skipped`
- [ ] Post-deploy: `curl https://api.webwhen.ai/robots.txt` → `User-agent: *\nDisallow: /`
- [ ] Post-deploy: `curl -sI https://api.webwhen.ai/sitemap.xml` → 404
- [ ] Post-deploy: `curl https://webwhen.ai/robots.txt` still lists `Sitemap:` and `Disallow:` rules
- [ ] Post-deploy: `curl https://webwhen.ai/sitemap.xml` still returns the sitemap index