### PR TITLE
chore(seo): drop torale.ai from CSP, footer reshuffle (#wave-1-tail)

### DIFF
--- a/backend/src/torale/api/main.py
+++ b/backend/src/torale/api/main.py
@@ -62,7 +62,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             "style-src 'self' 'unsafe-inline'; "
             "img-src 'self' data:; "
             "font-src 'self'; "
-            "connect-src 'self' https://*.torale.ai; "
+            "connect-src 'self' https://*.webwhen.ai; "
             "frame-ancestors 'none'; "
             "object-src 'none'; "
             "base-uri 'self';"

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -25,14 +25,11 @@ server {
     # location blocks regardless of what they do with `add_header`.
     #
     # CSP allowlist details:
-    # - img-src + connect-src admit *.webwhen.ai alongside *.torale.ai for the
-    #   rebrand soak window (frontend served on webwhen.ai still fetches
-    #   backend on api.torale.ai during soak; cutover-day strip removes the
-    #   torale entries).
-    # - script-src + frame-src admit clerk.webwhen.ai alongside clerk.torale.ai
-    #   for the rebrand cutover (Clerk primary domain flipped 2026-05-03;
-    #   old clerk.torale.ai may still serve briefly during DNS propagation).
-    #   Strip clerk.torale.ai post-cutover when DNS settles.
+    # - img-src + connect-src admit *.webwhen.ai (frontend → api).
+    # - script-src + frame-src admit clerk.webwhen.ai (Clerk primary domain
+    #   post-rebrand; the old clerk.torale.ai entry was retired once DNS
+    #   settled — verified via agent-browser that the live site loads zero
+    #   torale.ai hosts at runtime).
     # - script-src + frame-src admit challenges.cloudflare.com for Clerk's
     #   Bot Protection (Cloudflare Turnstile). The widget script + iframe
     #   both load from this origin; without it CAPTCHA fails to render and
@@ -42,7 +39,7 @@ server {
     more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload";
     more_set_headers "Referrer-Policy: strict-origin-when-cross-origin";
     more_set_headers "Permissions-Policy: geolocation=(), microphone=(), camera=()";
-    more_set_headers "Content-Security-Policy: default-src 'self'; script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://clerk.torale.ai https://clerk.webwhen.ai https://challenges.cloudflare.com https://static.cloudflareinsights.com https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://*.clerk.com https://*.torale.ai https://*.webwhen.ai; connect-src 'self' https://*.torale.ai https://*.webwhen.ai https://*.clerk.accounts.dev https://*.clerk.com https://api.clerk.com https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com; frame-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://clerk.torale.ai https://clerk.webwhen.ai https://challenges.cloudflare.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self';";
+    more_set_headers "Content-Security-Policy: default-src 'self'; script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://clerk.webwhen.ai https://challenges.cloudflare.com https://static.cloudflareinsights.com https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://*.clerk.com https://*.webwhen.ai; connect-src 'self' https://*.webwhen.ai https://*.clerk.accounts.dev https://*.clerk.com https://api.clerk.com https://eu.posthog.com https://eu.i.posthog.com https://eu-assets.i.posthog.com; frame-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://clerk.webwhen.ai https://challenges.cloudflare.com; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self';";
 
     rewrite ^/(.+)/$ /$1 permanent;
 

--- a/frontend/src/components/landing/Landing.module.css
+++ b/frontend/src/components/landing/Landing.module.css
@@ -522,7 +522,7 @@
 }
 .footerGrid {
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: 2fr 1fr 1fr 1fr 1fr 1fr;
   gap: 48px;
   padding-bottom: 64px;
   border-bottom: 1px solid #2A2A2D;

--- a/frontend/src/components/marketing/Footer.tsx
+++ b/frontend/src/components/marketing/Footer.tsx
@@ -34,13 +34,27 @@ export const Footer: React.FC = () => {
           <h4 className={styles.footerHeading}>Product</h4>
           <ul className={styles.footerList}>
             <li className={styles.footerListItem}>
-              <Link to="/dashboard">Dashboard</Link>
-            </li>
-            <li className={styles.footerListItem}>
               <Link to="/explore">Explore</Link>
             </li>
             <li className={styles.footerListItem}>
               <Link to="/changelog">Changelog</Link>
+            </li>
+            <li className={styles.footerListItem}>
+              <Link to="/concepts/self-scheduling-agents">Self-scheduling agents</Link>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h4 className={styles.footerHeading}>Compare</h4>
+          <ul className={styles.footerList}>
+            <li className={styles.footerListItem}>
+              <Link to="/compare/visualping-alternative">vs VisualPing</Link>
+            </li>
+            <li className={styles.footerListItem}>
+              <Link to="/compare/distill-alternative">vs Distill</Link>
+            </li>
+            <li className={styles.footerListItem}>
+              <Link to="/compare/changetower-alternative">vs ChangeTower</Link>
             </li>
           </ul>
         </div>
@@ -52,9 +66,6 @@ export const Footer: React.FC = () => {
             </li>
             <li className={styles.footerListItem}>
               <a href="https://github.com/prassanna-ravishankar/torale">GitHub</a>
-            </li>
-            <li className={styles.footerListItem}>
-              <Link to="/compare/visualping-alternative">Compare</Link>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Bundle of 3 SEO fixes per orchestrator. CSP cleanup (drop torale.ai from frontend nginx + backend api), footer reshuffle (drop /dashboard, add 3 compare + 1 concept link, new Compare column), grid 5→6 cols. Build clean, baked HTML verified, backend tests pass. CF purge needed post-merge on 11 prerendered routes (footer baked).