### PR TITLE
feat(landing): real watches power hero rotation + receipts cards

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -74,13 +74,15 @@ jobs:
           push: true
           provenance: false
           # Stage origin baked into prerendered JSON-LD / RSS / etc. for the
-          # frontend image only. Other components ignore the args.
-          # LANDING_EXAMPLES_API_ORIGIN points the prebuild snapshot fetch
-          # at the staging API (note: dash, not dot — the staging host is
-          # api-staging.webwhen.ai, not api.staging.webwhen.ai).
+          # frontend image only. Other components ignore the arg.
+          # Note: LANDING_EXAMPLES_API_ORIGIN is intentionally NOT set
+          # here. Marketing snapshot data is brand-curated and lives in
+          # the production public feed; staging builds bake from prod by
+          # design so stakeholders eyeballing the landing on staging see
+          # real watches, not an empty staging-API. See
+          # frontend/scripts/sync-landing-examples.mjs for the rationale.
           build-args: |
             PRERENDER_ORIGIN=https://staging.webwhen.ai
-            LANDING_EXAMPLES_API_ORIGIN=https://api-staging.webwhen.ai
           tags: |
             gcr.io/${{ env.GCP_PROJECT_ID }}/torale-${{ matrix.component }}:${{ env.IMAGE_TAG }}
             gcr.io/${{ env.GCP_PROJECT_ID }}/torale-${{ matrix.component }}:staging

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -74,9 +74,13 @@ jobs:
           push: true
           provenance: false
           # Stage origin baked into prerendered JSON-LD / RSS / etc. for the
-          # frontend image only. Other components ignore the arg.
+          # frontend image only. Other components ignore the args.
+          # LANDING_EXAMPLES_API_ORIGIN points the prebuild snapshot fetch
+          # at the staging API (note: dash, not dot — the staging host is
+          # api-staging.webwhen.ai, not api.staging.webwhen.ai).
           build-args: |
             PRERENDER_ORIGIN=https://staging.webwhen.ai
+            LANDING_EXAMPLES_API_ORIGIN=https://api-staging.webwhen.ai
           tags: |
             gcr.io/${{ env.GCP_PROJECT_ID }}/torale-${{ matrix.component }}:${{ env.IMAGE_TAG }}
             gcr.io/${{ env.GCP_PROJECT_ID }}/torale-${{ matrix.component }}:staging

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -14,6 +14,11 @@ node_modules
 # at build time. See scripts/prerender.mjs for the why.
 /.changelog-fixture.json
 
+# Synced from /api/v1/public/feed by scripts/sync-landing-examples.mjs at
+# build time. The committed src/data/landingExamples.fallback.json is the
+# safety net when the live fetch fails in CI.
+/.landing-examples-snapshot.json
+
 # Misc
 .DS_Store
 .env.local

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,6 +13,13 @@ WORKDIR /app
 ARG PRERENDER_ORIGIN
 ENV PRERENDER_ORIGIN=${PRERENDER_ORIGIN}
 
+# API origin used by scripts/sync-landing-examples.mjs at prebuild to fetch
+# the landing-page snapshot from /api/v1/public/feed. Defaults to the
+# production API; staging.yml overrides to https://api-staging.webwhen.ai
+# so staging builds bake staging-API watch evidence rather than prod's.
+ARG LANDING_EXAMPLES_API_ORIGIN
+ENV LANDING_EXAMPLES_API_ORIGIN=${LANDING_EXAMPLES_API_ORIGIN}
+
 # Copy package files
 COPY package*.json ./
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "prebuild": "node scripts/sync-changelog-fixture.mjs",
+    "prebuild": "node scripts/sync-changelog-fixture.mjs && node scripts/sync-landing-examples.mjs",
     "build": "vite build && node scripts/prerender.mjs && node scripts/generate-sitemap.mjs",
     "build:check": "tsc && vite build",
     "preview": "vite preview",

--- a/frontend/scripts/sync-landing-examples.mjs
+++ b/frontend/scripts/sync-landing-examples.mjs
@@ -32,12 +32,18 @@ const BAKE_TARGET = join(PROJECT_ROOT, 'src/data/landingExamples.fallback.json')
 // committed JSON.
 const DEBUG_OUT = join(PROJECT_ROOT, '.landing-examples-snapshot.json');
 
-// Explicit env var only. Earlier we tried to derive this by string-
-// replacing PRERENDER_ORIGIN, but the staging API host is
-// `api-staging.webwhen.ai` (dash), not `api.staging.webwhen.ai` (dot),
-// so the derivation silently fell back and staging builds saw prod.
-// staging.yml passes LANDING_EXAMPLES_API_ORIGIN=https://api-staging.webwhen.ai;
-// production builds rely on the default below.
+// Marketing snapshot data is brand-curated and lives in the production
+// public feed. Both staging and production images bake from prod by
+// design — the alternative (staging builds reading staging-API) showed
+// stakeholders an empty hero on staging because curated taskIds are
+// prod-only UUIDs. Same shape as the changelog fixture: one source of
+// truth, no per-env split.
+//
+// LANDING_EXAMPLES_API_ORIGIN remains an env var so a developer can
+// override locally (e.g. point at a fork of the API for testing), and
+// so the explicit-env-var mechanism is preserved (no string-replace
+// heuristics on PRERENDER_ORIGIN — that fell back silently when the
+// staging API host turned out to be `api-staging` not `api.staging`).
 const API_ORIGIN = process.env.LANDING_EXAMPLES_API_ORIGIN || 'https://api.webwhen.ai';
 
 // Public endpoints cap limit at 100. The feed already returns the most-

--- a/frontend/scripts/sync-landing-examples.mjs
+++ b/frontend/scripts/sync-landing-examples.mjs
@@ -1,0 +1,199 @@
+// Build-time fetch + bake of landing-page watch evidence.
+//
+// For each entry in src/data/landingExamples.ts, hits /api/v1/public/feed
+// for the latest successful execution, joins it with the curated config,
+// and writes .landing-examples-snapshot.json. The snapshot is consumed by
+// LandingExamplesContext at module-init so prerender bakes real evidence
+// into dist/index.html (and component first-paint matches hydration).
+//
+// Failure mode mirrors sync-changelog-fixture.mjs: if the fetch fails or
+// returns an empty feed, fall back to the committed
+// landingExamples.fallback.json so builds never break on an API blip. CI
+// surfaces a warning so we know it happened.
+
+import { writeFileSync, existsSync, copyFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { loadTsModule } from './_lib/load-ts.mjs';
+
+const PROJECT_ROOT = join(import.meta.dirname, '..');
+const CONFIG_TS = join(PROJECT_ROOT, 'src/data/landingExamples.ts');
+const FALLBACK = join(PROJECT_ROOT, 'src/data/landingExamples.fallback.json');
+const OUT = join(PROJECT_ROOT, '.landing-examples-snapshot.json');
+
+const API_ORIGIN =
+  process.env.LANDING_EXAMPLES_API_ORIGIN ||
+  process.env.PRERENDER_ORIGIN?.replace('://', '://api.').replace('https://api.https://', 'https://') ||
+  'https://api.webwhen.ai';
+
+// Public endpoints cap limit at 100. The feed already returns the most-
+// recent executions first, so 100 is enough to cover a curated set of ~10
+// landing examples even at heavy ingestion rates.
+const FEED_URL = `${API_ORIGIN}/api/v1/public/feed?limit=100`;
+const TASKS_URL = `${API_ORIGIN}/api/v1/public/tasks?limit=100`;
+
+// Editorial paraphrase of the agent's tool sequence. Hero composer log
+// shows verbs from this map; anything not mapped falls back to a sensible
+// default so a new tool slug doesn't crash the build.
+const TOOL_TO_VERB = {
+  search_memories: 'remembered',
+  perplexity_search: 'searched',
+  add_memory: 'noted',
+  final_result: 'settled',
+  fetch_url: 'read',
+  google_search: 'searched',
+  web_search: 'searched',
+};
+
+function paraphraseTool(tool) {
+  return TOOL_TO_VERB[tool] || 'checked';
+}
+
+function hostOf(url) {
+  try {
+    return new URL(url).host.replace(/^www\./, '');
+  } catch {
+    return url;
+  }
+}
+
+/** Trim evidence to a single sentence, max 220 chars, no orphan clauses. */
+function trimEvidence(text) {
+  if (!text) return '';
+  const cleaned = text.replace(/\s+/g, ' ').trim();
+  if (cleaned.length <= 220) return cleaned;
+  // Prefer the first sentence terminator inside the budget.
+  const slice = cleaned.slice(0, 220);
+  const lastTerm = Math.max(slice.lastIndexOf('. '), slice.lastIndexOf('! '), slice.lastIndexOf('? '));
+  if (lastTerm > 80) return slice.slice(0, lastTerm + 1);
+  // No clean break — fall back to soft truncation at last space.
+  const lastSpace = slice.lastIndexOf(' ');
+  return slice.slice(0, lastSpace > 0 ? lastSpace : 220) + '…';
+}
+
+/** Pick the 3 most-prominent source hosts from the execution. */
+function topHosts(execution) {
+  const sources =
+    execution?.result?.sources ||
+    execution?.grounding_sources ||
+    execution?.result?.grounding_sources ||
+    [];
+  const seen = new Set();
+  const hosts = [];
+  for (const s of sources) {
+    const h = hostOf(s.url || s);
+    if (h && !seen.has(h)) {
+      seen.add(h);
+      hosts.push(h);
+      if (hosts.length >= 3) break;
+    }
+  }
+  return hosts;
+}
+
+/** Render the activity log as ≤3 verb/detail pairs for the hero composer. */
+function paraphraseActivity(execution) {
+  const activity = execution?.result?.activity || [];
+  return activity
+    .filter((a) => a && a.tool)
+    .slice(0, 3)
+    .map((a) => ({
+      verb: paraphraseTool(a.tool),
+      detail: (a.detail || '').replace(/\s+/g, ' ').trim().slice(0, 80),
+    }));
+}
+
+async function fetchJson(url) {
+  const res = await fetch(url, { headers: { accept: 'application/json' } });
+  if (!res.ok) throw new Error(`${url} → HTTP ${res.status}`);
+  return res.json();
+}
+
+async function main() {
+  const { LANDING_EXAMPLES } = await loadTsModule(CONFIG_TS);
+
+  let feed = [];
+  let tasks = [];
+  let totalPublicConditions = 0;
+
+  try {
+    [feed, tasks] = await Promise.all([
+      fetchJson(FEED_URL),
+      fetchJson(TASKS_URL),
+    ]);
+    totalPublicConditions = tasks?.total ?? (Array.isArray(tasks?.tasks) ? tasks.tasks.length : 0);
+  } catch (err) {
+    console.warn(`[sync-landing-examples] live fetch failed (${err.message}); falling back to committed snapshot.`);
+    if (existsSync(FALLBACK)) {
+      copyFileSync(FALLBACK, OUT);
+      console.warn(`[sync-landing-examples] copied ${FALLBACK} → ${OUT}`);
+      return;
+    }
+    console.warn(`[sync-landing-examples] no fallback at ${FALLBACK}; writing empty snapshot.`);
+    writeFileSync(
+      OUT,
+      JSON.stringify({ totalPublicConditions: 0, syncedAt: new Date().toISOString(), examples: [] }, null, 2),
+      'utf-8',
+    );
+    return;
+  }
+
+  const tasksById = new Map((tasks?.tasks || []).map((t) => [t.id, t]));
+  // Prefer the most recent successful execution per task.
+  const latestExecByTask = new Map();
+  for (const exec of feed) {
+    if (!exec?.task_id || exec.status !== 'success') continue;
+    const prior = latestExecByTask.get(exec.task_id);
+    if (!prior || new Date(exec.started_at) > new Date(prior.started_at)) {
+      latestExecByTask.set(exec.task_id, exec);
+    }
+  }
+
+  const examples = [];
+  for (const cfg of LANDING_EXAMPLES) {
+    const task = tasksById.get(cfg.taskId);
+    const exec = latestExecByTask.get(cfg.taskId);
+    if (!task && !exec) {
+      console.warn(`[sync-landing-examples] no public data for taskId=${cfg.taskId} (${cfg.displayPrompt}); dropping.`);
+      continue;
+    }
+
+    const liveEvidence =
+      exec?.result?.evidence ||
+      task?.last_known_state?.evidence ||
+      exec?.notification ||
+      '';
+
+    examples.push({
+      taskId: cfg.taskId,
+      displayPrompt: cfg.displayPrompt,
+      tag: cfg.tag,
+      surfaces: cfg.surfaces,
+      startedAt: exec?.started_at || task?.state_changed_at || task?.updated_at || '',
+      state: task?.state || 'unknown',
+      evidence: trimEvidence(cfg.displayEvidenceOverride || liveEvidence),
+      sources: topHosts(exec),
+      activity: paraphraseActivity(exec),
+    });
+  }
+
+  const snapshot = {
+    totalPublicConditions,
+    syncedAt: new Date().toISOString(),
+    examples,
+  };
+
+  writeFileSync(OUT, JSON.stringify(snapshot, null, 2), 'utf-8');
+  console.log(
+    `[sync-landing-examples] baked ${examples.length}/${LANDING_EXAMPLES.length} watches → ${OUT} (total public: ${totalPublicConditions})`,
+  );
+}
+
+main().catch((err) => {
+  console.error(`[sync-landing-examples] FAIL: ${err.stack || err.message}`);
+  if (existsSync(FALLBACK)) {
+    copyFileSync(FALLBACK, OUT);
+    console.warn(`[sync-landing-examples] copied fallback after fatal error.`);
+    process.exit(0);
+  }
+  process.exit(1);
+});

--- a/frontend/scripts/sync-landing-examples.mjs
+++ b/frontend/scripts/sync-landing-examples.mjs
@@ -2,28 +2,44 @@
 //
 // For each entry in src/data/landingExamples.ts, hits /api/v1/public/feed
 // for the latest successful execution, joins it with the curated config,
-// and writes .landing-examples-snapshot.json. The snapshot is consumed by
-// LandingExamplesContext at module-init so prerender bakes real evidence
-// into dist/index.html (and component first-paint matches hydration).
+// and overwrites src/data/landingExamples.fallback.json — the JSON the
+// React tree actually imports at module init. So the file plays two
+// roles depending on context:
+//   - In CI: it is the *bake target*. Fresh data overwrites it before
+//     `vite build` reads the import.
+//   - In git: the committed copy is the *fallback*. If CI's fetch ever
+//     fails, the build still ships the last-known-good snapshot rather
+//     than blowing up.
 //
-// Failure mode mirrors sync-changelog-fixture.mjs: if the fetch fails or
-// returns an empty feed, fall back to the committed
-// landingExamples.fallback.json so builds never break on an API blip. CI
-// surfaces a warning so we know it happened.
+// .landing-examples-snapshot.json is also written as a debug artefact at
+// the repo root (gitignored). Useful for inspecting what the script saw
+// without diffing the committed JSON.
+//
+// Failure mode mirrors sync-changelog-fixture.mjs: if the fetch fails,
+// the existing committed JSON stays put and we exit cleanly with a warn.
 
-import { writeFileSync, existsSync, copyFileSync } from 'node:fs';
+import { writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { loadTsModule } from './_lib/load-ts.mjs';
 
 const PROJECT_ROOT = join(import.meta.dirname, '..');
 const CONFIG_TS = join(PROJECT_ROOT, 'src/data/landingExamples.ts');
-const FALLBACK = join(PROJECT_ROOT, 'src/data/landingExamples.fallback.json');
-const OUT = join(PROJECT_ROOT, '.landing-examples-snapshot.json');
+// The React tree imports this path at module init, so this is what we
+// must write. Vite's resolveJsonModule + bundler resolution turn it into
+// a static import that prerender then bakes into dist HTML.
+const BAKE_TARGET = join(PROJECT_ROOT, 'src/data/landingExamples.fallback.json');
+// Debug-only mirror, gitignored. Inspect this without git-diffing the
+// committed JSON.
+const DEBUG_OUT = join(PROJECT_ROOT, '.landing-examples-snapshot.json');
 
-const API_ORIGIN =
-  process.env.LANDING_EXAMPLES_API_ORIGIN ||
-  process.env.PRERENDER_ORIGIN?.replace('://', '://api.').replace('https://api.https://', 'https://') ||
-  'https://api.webwhen.ai';
+// Explicit env var only. Earlier we tried to derive this by string-
+// replacing PRERENDER_ORIGIN, but the staging API host is
+// `api-staging.webwhen.ai` (dash), not `api.staging.webwhen.ai` (dot),
+// so the derivation silently fell back to the default and CI builds
+// always saw production. CI workflows now set this explicitly per env:
+// staging.yml → https://api-staging.webwhen.ai
+// production.yml → https://api.webwhen.ai
+const API_ORIGIN = process.env.LANDING_EXAMPLES_API_ORIGIN || 'https://api.webwhen.ai';
 
 // Public endpoints cap limit at 100. The feed already returns the most-
 // recent executions first, so 100 is enough to cover a curated set of ~10
@@ -122,18 +138,17 @@ async function main() {
     ]);
     totalPublicConditions = tasks?.total ?? (Array.isArray(tasks?.tasks) ? tasks.tasks.length : 0);
   } catch (err) {
-    console.warn(`[sync-landing-examples] live fetch failed (${err.message}); falling back to committed snapshot.`);
-    if (existsSync(FALLBACK)) {
-      copyFileSync(FALLBACK, OUT);
-      console.warn(`[sync-landing-examples] copied ${FALLBACK} → ${OUT}`);
-      return;
+    // Fetch failed. The committed bake target stays untouched — Vite will
+    // import the last-known-good snapshot. Write the debug mirror anyway
+    // so we know the script ran but bailed.
+    console.warn(`[sync-landing-examples] live fetch failed (${err.message}); using committed snapshot at ${BAKE_TARGET}.`);
+    if (!existsSync(BAKE_TARGET)) {
+      // No committed snapshot to fall back to — write an empty one so
+      // the import resolves rather than crashing the build.
+      const empty = { totalPublicConditions: 0, syncedAt: new Date().toISOString(), examples: [] };
+      writeFileSync(BAKE_TARGET, JSON.stringify(empty, null, 2), 'utf-8');
+      console.warn(`[sync-landing-examples] no committed snapshot existed; wrote empty placeholder.`);
     }
-    console.warn(`[sync-landing-examples] no fallback at ${FALLBACK}; writing empty snapshot.`);
-    writeFileSync(
-      OUT,
-      JSON.stringify({ totalPublicConditions: 0, syncedAt: new Date().toISOString(), examples: [] }, null, 2),
-      'utf-8',
-    );
     return;
   }
 
@@ -182,18 +197,23 @@ async function main() {
     examples,
   };
 
-  writeFileSync(OUT, JSON.stringify(snapshot, null, 2), 'utf-8');
+  const serialized = JSON.stringify(snapshot, null, 2);
+  // Bake target = the import the React tree resolves at module init.
+  // Overwriting this makes the live fetch visible to vite build (and
+  // therefore to prerender's baked HTML).
+  writeFileSync(BAKE_TARGET, serialized, 'utf-8');
+  // Debug mirror at repo root, gitignored. Inspect this to see what the
+  // script saw without producing a noisy git diff on every CI run.
+  writeFileSync(DEBUG_OUT, serialized, 'utf-8');
   console.log(
-    `[sync-landing-examples] baked ${examples.length}/${LANDING_EXAMPLES.length} watches → ${OUT} (total public: ${totalPublicConditions})`,
+    `[sync-landing-examples] baked ${examples.length}/${LANDING_EXAMPLES.length} watches → ${BAKE_TARGET} (total public: ${totalPublicConditions}, origin: ${API_ORIGIN})`,
   );
 }
 
 main().catch((err) => {
+  // Don't tear down the build on a partial failure — leave the committed
+  // bake target alone so the React tree still has *something* to import.
   console.error(`[sync-landing-examples] FAIL: ${err.stack || err.message}`);
-  if (existsSync(FALLBACK)) {
-    copyFileSync(FALLBACK, OUT);
-    console.warn(`[sync-landing-examples] copied fallback after fatal error.`);
-    process.exit(0);
-  }
-  process.exit(1);
+  console.warn(`[sync-landing-examples] leaving committed snapshot at ${BAKE_TARGET} untouched.`);
+  process.exit(0);
 });

--- a/frontend/scripts/sync-landing-examples.mjs
+++ b/frontend/scripts/sync-landing-examples.mjs
@@ -24,6 +24,7 @@ import { loadTsModule } from './_lib/load-ts.mjs';
 
 const PROJECT_ROOT = join(import.meta.dirname, '..');
 const CONFIG_TS = join(PROJECT_ROOT, 'src/data/landingExamples.ts');
+const UTILS_TS = join(PROJECT_ROOT, 'src/utils/landingExamples.ts');
 // The React tree imports this path at module init, so this is what we
 // must write. Vite's resolveJsonModule + bundler resolution turn it into
 // a static import that prerender then bakes into dist HTML.
@@ -52,44 +53,11 @@ const API_ORIGIN = process.env.LANDING_EXAMPLES_API_ORIGIN || 'https://api.webwh
 const FEED_URL = `${API_ORIGIN}/api/v1/public/feed?limit=100`;
 const TASKS_URL = `${API_ORIGIN}/api/v1/public/tasks?limit=100`;
 
-// Editorial paraphrase of the agent's tool sequence. Hero composer log
-// shows verbs from this map; anything not mapped falls back to a sensible
-// default so a new tool slug doesn't crash the build.
-const TOOL_TO_VERB = {
-  search_memories: 'remembered',
-  perplexity_search: 'searched',
-  add_memory: 'noted',
-  final_result: 'settled',
-  fetch_url: 'read',
-  google_search: 'searched',
-  web_search: 'searched',
-};
-
-function paraphraseTool(tool) {
-  return TOOL_TO_VERB[tool] || 'checked';
-}
-
-function hostOf(url) {
-  try {
-    return new URL(url).host.replace(/^www\./, '');
-  } catch {
-    return url;
-  }
-}
-
-/** Trim evidence to a single sentence, max 220 chars, no orphan clauses. */
-function trimEvidence(text) {
-  if (!text) return '';
-  const cleaned = text.replace(/\s+/g, ' ').trim();
-  if (cleaned.length <= 220) return cleaned;
-  // Prefer the first sentence terminator inside the budget.
-  const slice = cleaned.slice(0, 220);
-  const lastTerm = Math.max(slice.lastIndexOf('. '), slice.lastIndexOf('! '), slice.lastIndexOf('? '));
-  if (lastTerm > 80) return slice.slice(0, lastTerm + 1);
-  // No clean break — fall back to soft truncation at last space.
-  const lastSpace = slice.lastIndexOf(' ');
-  return slice.slice(0, lastSpace > 0 ? lastSpace : 220) + '…';
-}
+// Shared helpers live in src/utils/landingExamples.ts so the React tree
+// and this build script can't drift apart on verb mapping, host parsing,
+// or evidence-trim budget (gemini #uM). Loaded via esbuild→data-URL so
+// the .mjs build script can consume the .ts module.
+const { paraphraseTool, hostOf, trimEvidence } = await loadTsModule(UTILS_TS);
 
 /** Pick the 3 most-prominent source hosts from the execution. */
 function topHosts(execution) {
@@ -101,7 +69,7 @@ function topHosts(execution) {
   const seen = new Set();
   const hosts = [];
   for (const s of sources) {
-    const h = hostOf(s.url || s);
+    const h = hostOf(s);
     if (h && !seen.has(h)) {
       seen.add(h);
       hosts.push(h);

--- a/frontend/scripts/sync-landing-examples.mjs
+++ b/frontend/scripts/sync-landing-examples.mjs
@@ -35,10 +35,9 @@ const DEBUG_OUT = join(PROJECT_ROOT, '.landing-examples-snapshot.json');
 // Explicit env var only. Earlier we tried to derive this by string-
 // replacing PRERENDER_ORIGIN, but the staging API host is
 // `api-staging.webwhen.ai` (dash), not `api.staging.webwhen.ai` (dot),
-// so the derivation silently fell back to the default and CI builds
-// always saw production. CI workflows now set this explicitly per env:
-// staging.yml → https://api-staging.webwhen.ai
-// production.yml → https://api.webwhen.ai
+// so the derivation silently fell back and staging builds saw prod.
+// staging.yml passes LANDING_EXAMPLES_API_ORIGIN=https://api-staging.webwhen.ai;
+// production builds rely on the default below.
 const API_ORIGIN = process.env.LANDING_EXAMPLES_API_ORIGIN || 'https://api.webwhen.ai';
 
 // Public endpoints cap limit at 100. The feed already returns the most-
@@ -118,10 +117,30 @@ function paraphraseActivity(execution) {
     }));
 }
 
+// Bare fetch() inherits Node's 10-minute socket timeout, which would
+// stretch every Docker build by minutes if the API is slow or down.
+// 15s is comfortably more than the API needs in healthy state and short
+// enough to fail fast into the committed-snapshot fallback path.
+const FETCH_TIMEOUT_MS = 15000;
+
 async function fetchJson(url) {
-  const res = await fetch(url, { headers: { accept: 'application/json' } });
-  if (!res.ok) throw new Error(`${url} → HTTP ${res.status}`);
-  return res.json();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      headers: { accept: 'application/json' },
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`${url} → HTTP ${res.status}`);
+    return await res.json();
+  } catch (err) {
+    if (err?.name === 'AbortError') {
+      throw new Error(`${url} → timed out after ${FETCH_TIMEOUT_MS}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 async function main() {
@@ -138,9 +157,10 @@ async function main() {
     ]);
     totalPublicConditions = tasks?.total ?? (Array.isArray(tasks?.tasks) ? tasks.tasks.length : 0);
   } catch (err) {
-    // Fetch failed. The committed bake target stays untouched — Vite will
-    // import the last-known-good snapshot. Write the debug mirror anyway
-    // so we know the script ran but bailed.
+    // Fetch failed. The committed bake target stays untouched — Vite
+    // will import the last-known-good snapshot. The debug mirror at
+    // DEBUG_OUT is intentionally not refreshed; if you need to know what
+    // CI saw, the warn line below is the audit trail.
     console.warn(`[sync-landing-examples] live fetch failed (${err.message}); using committed snapshot at ${BAKE_TARGET}.`);
     if (!existsSync(BAKE_TARGET)) {
       // No committed snapshot to fall back to — write an empty one so

--- a/frontend/src/components/Landing.tsx
+++ b/frontend/src/components/Landing.tsx
@@ -5,6 +5,7 @@ import { Steps } from "@/components/landing/Steps";
 import { Cases } from "@/components/landing/Cases";
 import { Manifesto } from "@/components/landing/Manifesto";
 import { CTA } from "@/components/landing/CTA";
+import { LandingExamplesProvider } from "@/contexts/LandingExamplesContext";
 
 /**
  * webwhen marketing landing page.
@@ -46,11 +47,13 @@ export default function Landing() {
           }).replace(/</g, "\\u003c"),
         }}
       />
-      <Hero />
-      <Steps />
-      <Cases />
-      <Manifesto />
-      <CTA />
+      <LandingExamplesProvider>
+        <Hero />
+        <Steps />
+        <Cases />
+        <Manifesto />
+        <CTA />
+      </LandingExamplesProvider>
     </MarketingLayout>
   );
 }

--- a/frontend/src/components/landing/Cases.tsx
+++ b/frontend/src/components/landing/Cases.tsx
@@ -1,40 +1,55 @@
+import { useLandingExamples } from '@/contexts/LandingExamplesContext'
 import { cn } from '@/lib/utils'
 
 import styles from './Landing.module.css'
 
+function shortDate(iso: string): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
 export const Cases: React.FC = () => {
+  const { cases } = useLandingExamples()
+
+  if (cases.length === 0) return null
+
   return (
     <section className={cn(styles.section, styles.sectionAlt)} id="cases">
       <div className={styles.container}>
-        <div className={styles.eyebrow}>Use cases</div>
+        <div className={styles.eyebrow}>Receipts</div>
         <h2 className={styles.sectionHeading}>
           If it lives on the open web,{' '}
           <span className={styles.sectionHeadingAccent}>webwhen can wait for it.</span>
         </h2>
         <div className={styles.cases}>
-          <div className={styles.caseCard}>
-            <div className={styles.caseTag}>availability · retail</div>
-            <p className={styles.caseQuestion}>
-              Alert me when the PS5 is back in stock at Best Buy.
-            </p>
-            <div className={styles.caseResult}>
-              <span className={styles.caseResultOk}>condition met</span> · 4m ago
-            </div>
-          </div>
-          <div className={styles.caseCard}>
-            <div className={styles.caseTag}>launches · industry</div>
-            <p className={styles.caseQuestion}>
-              Tell me when the next iPhone release date is announced.
-            </p>
-            <div className={styles.caseResult}>watching · run #284</div>
-          </div>
-          <div className={styles.caseCard}>
-            <div className={styles.caseTag}>competitive intel</div>
-            <p className={styles.caseQuestion}>
-              Notify me when Linear changes Enterprise tier pricing.
-            </p>
-            <div className={styles.caseResult}>watching · checked 2h ago</div>
-          </div>
+          {cases.map((entry) => {
+            const settled = entry.state === 'completed'
+            const stateLabel = settled ? 'settled' : 'watching'
+            const date = shortDate(entry.startedAt)
+            return (
+              <article key={entry.taskId} className={styles.caseCard}>
+                <div className={styles.caseTag}>{entry.tag}</div>
+                <p className={styles.caseQuestion}>{entry.displayPrompt}</p>
+                {entry.evidence && (
+                  <p className={styles.caseEvidence}>{entry.evidence}</p>
+                )}
+                {entry.sources.length > 0 && (
+                  <div className={styles.caseSources}>
+                    {entry.sources.join(' · ')}
+                  </div>
+                )}
+                <div className={styles.caseResult}>
+                  <span className={cn(styles.caseState, settled && styles.caseStateSettled)}>
+                    <span className={styles.caseStateDot}></span>
+                    {stateLabel}
+                  </span>
+                  {date && <span>{date}</span>}
+                </div>
+              </article>
+            )
+          })}
         </div>
       </div>
     </section>

--- a/frontend/src/components/landing/Hero.tsx
+++ b/frontend/src/components/landing/Hero.tsx
@@ -21,6 +21,19 @@ function prefersReducedMotion(): boolean {
   return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
 }
 
+/**
+ * Inside scripts/prerender.mjs Playwright sets `window.__PRERENDER__ = true`
+ * before navigating. Gating the cycle effect on this flag stops the state
+ * machine from advancing during prerender — so the captured HTML is
+ * always idle/full-prompt-#0, regardless of how long Playwright takes to
+ * settle on `networkidle`. Defence-in-depth alongside the deterministic
+ * first-paint state.
+ */
+function isPrerender(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.__PRERENDER__ === true
+}
+
 /** Render a date as "May 9" — absolute, deterministic across SSR/CSR. */
 function shortDate(iso: string): string {
   if (!iso) return ''
@@ -47,8 +60,16 @@ export const Hero: React.FC = () => {
   useEffect(() => {
     if (hero.length <= 1) return
     if (paused) return
+    // Don't run the typewriter while Playwright is capturing the prerender
+    // shell — keeps captured HTML deterministic regardless of settle time.
+    if (isPrerender()) return
     if (prefersReducedMotion()) {
-      // Reduced motion: instant swap on the same 4.5s cadence (IDLE+a bit).
+      // Reduced motion: instant swap, no character animation. The cadence
+      // here is intentionally a touch longer than IDLE_MS alone (since the
+      // animated path eats real seconds typing/deleting on top of IDLE_MS,
+      // a pure idle dwell would feel rushed). 4500ms was chosen as a
+      // reasonable approximation of the perceived rhythm without being
+      // load-bearing — tune freely.
       // Use the ref as source of truth for "where we are" so this effect
       // doesn't need `index` in its deps (which would re-arm on every tick).
       const id = window.setTimeout(() => {
@@ -137,22 +158,29 @@ export const Hero: React.FC = () => {
           onMouseEnter={() => setPaused(true)}
           onMouseLeave={() => setPaused(false)}
         >
-          <div className={styles.composer} aria-live="polite">
+          <div className={styles.composer}>
             <div className={styles.composerHead}>
               <span>new watch</span>
               <span>plain english · no rules</span>
             </div>
             <div className={styles.composerBody}>
-              <p className={styles.composerPrompt}>
+              {/* The animated text itself is aria-hidden — character-level
+                  mutation would otherwise spam screen readers with one
+                  announcement per keystroke. The sr-only mirror below
+                  carries aria-live and only updates with the settled
+                  prompt, so SR users hear each prompt once per cycle. */}
+              <p className={styles.composerPrompt} aria-hidden="true">
                 {typed}
                 <span
                   className={cn(
                     styles.composerCursor,
                     isAnimating && styles.composerCursorWorking,
                   )}
-                  aria-hidden="true"
                 ></span>
               </p>
+              <span className={styles.srOnly} aria-live="polite" aria-atomic="true">
+                {phase === 'idle' ? current?.displayPrompt ?? '' : ''}
+              </span>
               <p className={styles.composerSub}>
                 webwhen will sit with this and decide when to check.
               </p>

--- a/frontend/src/components/landing/Hero.tsx
+++ b/frontend/src/components/landing/Hero.tsx
@@ -189,12 +189,17 @@ export const Hero: React.FC = () => {
               <div>
                 <span className={styles.chip}>{current?.tag ?? 'nothing to tune'}</span>
               </div>
-              <button
+              {/* Watch button deep-links to /explore where the visitor can
+                  see the public feed in real time. We can't link to a
+                  per-task page because /tasks/:id requires auth; /explore
+                  is the public surface for "what webwhen is doing now". */}
+              <Link
+                to="/explore"
                 className={cn(styles.btn, styles.btnPrimary)}
                 style={{ padding: '8px 14px' }}
               >
                 Watch <span style={{ fontFamily: 'var(--ww-font-mono)' }}>→</span>
-              </button>
+              </Link>
             </div>
           </div>
           <div className={styles.log}>

--- a/frontend/src/components/landing/Hero.tsx
+++ b/frontend/src/components/landing/Hero.tsx
@@ -1,17 +1,54 @@
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 
+import { useLandingExamples } from '@/contexts/LandingExamplesContext'
 import { cn } from '@/lib/utils'
 
 import styles from './Landing.module.css'
 
+const CYCLE_MS = 4500
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+}
+
+/** Render a date as "May 9" — absolute, deterministic across SSR/CSR. */
+function shortDate(iso: string): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
 export const Hero: React.FC = () => {
+  const { hero, snapshot } = useLandingExamples()
+  // Deterministic first paint: always start at index 0 regardless of how
+  // the snapshot was generated. Cycling is opt-in via useEffect, so the
+  // SSR/prerender HTML and the React first paint render identical content.
+  const [index, setIndex] = useState(0)
+  const [paused, setPaused] = useState(false)
+
+  useEffect(() => {
+    if (hero.length <= 1) return
+    if (prefersReducedMotion()) return
+    if (paused) return
+    const id = window.setTimeout(() => {
+      setIndex((i) => (i + 1) % hero.length)
+    }, CYCLE_MS)
+    return () => window.clearTimeout(id)
+  }, [index, paused, hero.length])
+
+  const current = hero[index] ?? hero[0]
+  const liveCount = snapshot.totalPublicConditions
+
   return (
     <section className={styles.hero}>
       <div className={cn(styles.container, styles.heroGrid)}>
         <div>
           <div className={styles.heroMeta}>
             <span className={styles.liveDot}></span>
-            watching · 2,841 conditions
+            watching · {liveCount.toLocaleString('en-US')} {liveCount === 1 ? 'condition' : 'conditions'}
           </div>
           <h1 className={styles.heroTitle}>
             Get notified <span className={styles.heroEmber}>when</span> it matters.
@@ -25,15 +62,18 @@ export const Hero: React.FC = () => {
             </Link>
           </div>
         </div>
-        <div>
-          <div className={styles.composer}>
+        <div
+          onMouseEnter={() => setPaused(true)}
+          onMouseLeave={() => setPaused(false)}
+        >
+          <div className={styles.composer} aria-live="polite">
             <div className={styles.composerHead}>
               <span>new watch</span>
               <span>plain english · no rules</span>
             </div>
             <div className={styles.composerBody}>
               <p className={styles.composerPrompt}>
-                Tell me when the PS5 is back in stock at Best Buy.
+                {current?.displayPrompt ?? 'Tell webwhen what to watch for.'}
                 <span className={styles.composerCursor}></span>
               </p>
               <p className={styles.composerSub}>
@@ -42,7 +82,7 @@ export const Hero: React.FC = () => {
             </div>
             <div className={styles.composerFoot}>
               <div>
-                <span className={styles.chip}>nothing to tune</span>
+                <span className={styles.chip}>{current?.tag ?? 'nothing to tune'}</span>
               </div>
               <button
                 className={cn(styles.btn, styles.btnPrimary)}
@@ -53,21 +93,23 @@ export const Hero: React.FC = () => {
             </div>
           </div>
           <div className={styles.log}>
-            <div className={styles.logItem}>
-              <span className={styles.logItemTime}>14:32</span>
-              <span className={styles.logItemDot}></span>
-              <span className={styles.logItemBody}>checked bestbuy.com · listing live</span>
-            </div>
-            <div className={styles.logItem}>
-              <span className={styles.logItemTime}>14:32</span>
-              <span className={styles.logItemDot}></span>
-              <span className={styles.logItemBody}>corroborated · polygon.com, r/PS5</span>
-            </div>
-            <div className={cn(styles.logItem, styles.logItemEmber)}>
-              <span className={styles.logItemTime}>14:32</span>
-              <span className={styles.logItemDot}></span>
-              <span className={styles.logItemBody}>condition met · sending notification</span>
-            </div>
+            {(current?.activity ?? []).map((step, i, arr) => {
+              const isLast = i === arr.length - 1
+              const date = shortDate(current?.startedAt ?? '')
+              return (
+                <div
+                  key={`${current?.taskId}-${i}`}
+                  className={cn(styles.logItem, isLast && styles.logItemEmber)}
+                >
+                  <span className={styles.logItemTime}>{date || '—'}</span>
+                  <span className={styles.logItemDot}></span>
+                  <span className={styles.logItemBody}>
+                    {step.verb}
+                    {step.detail ? ` · ${step.detail}` : ''}
+                  </span>
+                </div>
+              )
+            })}
           </div>
         </div>
       </div>

--- a/frontend/src/components/landing/Hero.tsx
+++ b/frontend/src/components/landing/Hero.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 
 import { useLandingExamples } from '@/contexts/LandingExamplesContext'
@@ -6,7 +6,15 @@ import { cn } from '@/lib/utils'
 
 import styles from './Landing.module.css'
 
-const CYCLE_MS = 4500
+// === Cycle pacing ====================================================
+// `IDLE_MS` is the dwell after a prompt is fully typed — the time the
+// reader actually sees the full sentence. Type/delete chew through their
+// own time on top.
+const IDLE_MS = 3000
+const TYPE_MS_PER_CHAR = 28
+const DELETE_MS_PER_CHAR = 18
+
+type Phase = 'idle' | 'deleting' | 'typing'
 
 function prefersReducedMotion(): boolean {
   if (typeof window === 'undefined') return false
@@ -23,24 +31,87 @@ function shortDate(iso: string): string {
 
 export const Hero: React.FC = () => {
   const { hero, snapshot } = useLandingExamples()
-  // Deterministic first paint: always start at index 0 regardless of how
-  // the snapshot was generated. Cycling is opt-in via useEffect, so the
-  // SSR/prerender HTML and the React first paint render identical content.
+
+  // Deterministic first paint: index 0, full prompt, idle phase. The
+  // cycle starts only inside useEffect so the SSR/prerender HTML and the
+  // React first paint render identical content.
   const [index, setIndex] = useState(0)
   const [paused, setPaused] = useState(false)
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [typed, setTyped] = useState<string>(() => hero[0]?.displayPrompt ?? '')
+
+  // Track the prompt the typewriter is animating toward. Lets us cleanly
+  // start a delete-then-type sequence each cycle without racing setState.
+  const targetIndexRef = useRef(0)
 
   useEffect(() => {
     if (hero.length <= 1) return
-    if (prefersReducedMotion()) return
     if (paused) return
-    const id = window.setTimeout(() => {
-      setIndex((i) => (i + 1) % hero.length)
-    }, CYCLE_MS)
-    return () => window.clearTimeout(id)
-  }, [index, paused, hero.length])
+    if (prefersReducedMotion()) {
+      // Reduced motion: instant swap on the same 4.5s cadence (IDLE+a bit).
+      // Use the ref as source of truth for "where we are" so this effect
+      // doesn't need `index` in its deps (which would re-arm on every tick).
+      const id = window.setTimeout(() => {
+        const next = (targetIndexRef.current + 1) % hero.length
+        targetIndexRef.current = next
+        setIndex(next)
+        setTyped(hero[next]?.displayPrompt ?? '')
+      }, IDLE_MS + 1500)
+      return () => window.clearTimeout(id)
+    }
+
+    let cancelled = false
+    let timeoutId: number | undefined
+
+    const tickDelete = () => {
+      if (cancelled) return
+      setTyped((prev) => {
+        if (prev.length <= 1) {
+          // Last char deleted — flip to typing the next prompt.
+          const next = (targetIndexRef.current + 1) % hero.length
+          targetIndexRef.current = next
+          setIndex(next)
+          setPhase('typing')
+          return ''
+        }
+        timeoutId = window.setTimeout(tickDelete, DELETE_MS_PER_CHAR)
+        return prev.slice(0, -1)
+      })
+    }
+
+    const tickType = () => {
+      if (cancelled) return
+      const target = hero[targetIndexRef.current]?.displayPrompt ?? ''
+      setTyped((prev) => {
+        if (prev.length >= target.length) {
+          setPhase('idle')
+          return target
+        }
+        timeoutId = window.setTimeout(tickType, TYPE_MS_PER_CHAR)
+        return target.slice(0, prev.length + 1)
+      })
+    }
+
+    if (phase === 'idle') {
+      timeoutId = window.setTimeout(() => {
+        if (cancelled) return
+        setPhase('deleting')
+      }, IDLE_MS)
+    } else if (phase === 'deleting') {
+      timeoutId = window.setTimeout(tickDelete, DELETE_MS_PER_CHAR)
+    } else if (phase === 'typing') {
+      timeoutId = window.setTimeout(tickType, TYPE_MS_PER_CHAR)
+    }
+
+    return () => {
+      cancelled = true
+      if (timeoutId !== undefined) window.clearTimeout(timeoutId)
+    }
+  }, [phase, paused, hero])
 
   const current = hero[index] ?? hero[0]
   const liveCount = snapshot.totalPublicConditions
+  const isAnimating = phase !== 'idle'
 
   return (
     <section className={styles.hero}>
@@ -73,8 +144,14 @@ export const Hero: React.FC = () => {
             </div>
             <div className={styles.composerBody}>
               <p className={styles.composerPrompt}>
-                {current?.displayPrompt ?? 'Tell webwhen what to watch for.'}
-                <span className={styles.composerCursor}></span>
+                {typed}
+                <span
+                  className={cn(
+                    styles.composerCursor,
+                    isAnimating && styles.composerCursorWorking,
+                  )}
+                  aria-hidden="true"
+                ></span>
               </p>
               <p className={styles.composerSub}>
                 webwhen will sit with this and decide when to check.

--- a/frontend/src/components/landing/Landing.module.css
+++ b/frontend/src/components/landing/Landing.module.css
@@ -219,6 +219,21 @@
   background: var(--ww-ink-3);
   animation: none;
 }
+/* Accessibility-only mirror of the settled composer prompt. The visible
+   prompt is aria-hidden because per-character DOM mutation would spam
+   screen readers; this element carries aria-live and only updates when
+   the typewriter settles, so SR users hear each prompt once per cycle. */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 .composerSub {
   font-family: var(--ww-font-sans);
   font-size: 13px;

--- a/frontend/src/components/landing/Landing.module.css
+++ b/frontend/src/components/landing/Landing.module.css
@@ -210,6 +210,14 @@
   margin-left: 2px;
   vertical-align: -3px;
   animation: blink 1.05s steps(2, start) infinite;
+  transition: background var(--ww-dur-fast) var(--ww-ease-out);
+}
+/* While the typewriter is actively chewing through chars the cursor
+   stops blinking and shifts to ink-3 — reads as "working" rather than
+   "ready". Returns to ember + blink the moment the prompt settles. */
+.composerCursorWorking {
+  background: var(--ww-ink-3);
+  animation: none;
 }
 .composerSub {
   font-family: var(--ww-font-sans);

--- a/frontend/src/components/landing/Landing.module.css
+++ b/frontend/src/components/landing/Landing.module.css
@@ -443,6 +443,43 @@
   background: var(--ww-success);
 }
 
+/* Receipts: editorial pull-quote register for the agent's evidence text.
+   Italic Instrument Serif lifts real notification prose into the brand
+   voice without adding visual chrome. */
+.caseEvidence {
+  font-family: var(--ww-font-serif);
+  font-style: italic;
+  font-size: 17px;
+  line-height: 1.45;
+  color: var(--ww-ink-2);
+  margin: 0 0 16px;
+  text-wrap: pretty;
+}
+.caseSources {
+  font-family: var(--ww-font-mono);
+  font-size: 11px;
+  color: var(--ww-ink-3);
+  letter-spacing: -0.01em;
+  margin-bottom: 10px;
+}
+.caseState {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.caseStateDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--ww-ink-4);
+}
+.caseStateSettled {
+  color: var(--ww-ember);
+}
+.caseStateSettled .caseStateDot {
+  background: var(--ww-ember);
+}
+
 /* === Manifesto ====================================================== */
 .manifesto {
   display: grid;

--- a/frontend/src/contexts/LandingExamplesContext.tsx
+++ b/frontend/src/contexts/LandingExamplesContext.tsx
@@ -123,10 +123,22 @@ function mergeExecution(
   };
 }
 
+/**
+ * Inside scripts/prerender.mjs Playwright sets window.__PRERENDER__ = true
+ * before navigating. Skip the runtime revalidation fetch under prerender
+ * so the captured HTML is always the build-time bake — no race between
+ * the in-flight fetch resolving and `page.content()` capturing.
+ */
+function isPrerender(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.__PRERENDER__ === true;
+}
+
 export function LandingExamplesProvider({ children }: { children: ReactNode }) {
   const [snapshot, setSnapshot] = useState<LandingSnapshot>(FALLBACK);
 
   useEffect(() => {
+    if (isPrerender()) return;
     let cancelled = false;
     api
       .getPublicFeed(100)

--- a/frontend/src/contexts/LandingExamplesContext.tsx
+++ b/frontend/src/contexts/LandingExamplesContext.tsx
@@ -6,10 +6,13 @@
 // React first paint structurally identical, avoiding hydration mismatches.
 //
 // Post-hydration: the provider fires a single fetch against
-// /api/v1/public/feed (+ /api/v1/public/tasks for the live count) and
-// merges fresher executions into the in-memory snapshot keyed by taskId.
-// Both Hero (rotation) and Cases (Receipts) read from this context so a
-// rogue task on /explore can't surface twice.
+// /api/v1/public/feed and merges fresher executions into the in-memory
+// snapshot keyed by taskId. The "watching · N conditions" count chip
+// stays as whatever the build-time bake captured because the bake
+// reads prod cross-env while the runtime API client is per-env (see
+// the useEffect comment below for the full reasoning). Both Hero
+// (rotation) and Cases (Receipts) read from this context so a rogue
+// task on /explore can't surface twice.
 
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { LANDING_EXAMPLES, type LandingSnapshot, type LandingExampleSnapshot } from '@/data/landingExamples';
@@ -130,9 +133,14 @@ export function LandingExamplesProvider({ children }: { children: ReactNode }) {
       .getPublicFeed(100)
       .then((feed) => {
         if (cancelled || !Array.isArray(feed)) return;
+        // Narrow the merge to only the curated taskIds. The feed can
+        // contain unrelated public executions; filtering here means the
+        // skip-set guard below reflects the actual "did anything we
+        // care about refresh?" question.
         const latestByTask = new Map<string, FeedExecutionLike>();
         for (const exec of feed as unknown as FeedExecutionLike[]) {
           if (!exec?.task_id || exec.status !== 'success') continue;
+          if (!CONFIG_BY_ID.has(exec.task_id)) continue;
           const prior = latestByTask.get(exec.task_id);
           if (!prior || new Date(exec.started_at || 0) > new Date(prior.started_at || 0)) {
             latestByTask.set(exec.task_id, exec);

--- a/frontend/src/contexts/LandingExamplesContext.tsx
+++ b/frontend/src/contexts/LandingExamplesContext.tsx
@@ -1,0 +1,178 @@
+// Single source of post-hydration revalidated landing-page watch state.
+//
+// First paint: returns the build-time snapshot baked by
+// scripts/sync-landing-examples.mjs (committed fallback at
+// src/data/landingExamples.fallback.json). This keeps prerender HTML and
+// React first paint structurally identical, avoiding hydration mismatches.
+//
+// Post-hydration: the provider fires a single fetch against
+// /api/v1/public/feed and merges fresher executions into the in-memory
+// snapshot keyed by taskId. Both Hero (rotation) and Cases (Receipts)
+// read from this context so a rogue task on /explore can't surface twice.
+
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { LANDING_EXAMPLES, type LandingSnapshot, type LandingExampleSnapshot } from '@/data/landingExamples';
+import fallbackJson from '@/data/landingExamples.fallback.json';
+import { api } from '@/lib/api';
+
+const FALLBACK = fallbackJson as LandingSnapshot;
+
+type ExampleBySurface = {
+  hero: LandingExampleSnapshot[];
+  cases: LandingExampleSnapshot[];
+};
+
+interface LandingExamplesContextValue {
+  snapshot: LandingSnapshot;
+  hero: LandingExampleSnapshot[];
+  cases: LandingExampleSnapshot[];
+}
+
+const LandingExamplesContext = createContext<LandingExamplesContextValue | null>(null);
+
+function partition(snapshot: LandingSnapshot): ExampleBySurface {
+  return {
+    hero: snapshot.examples.filter((e) => e.surfaces.includes('hero')),
+    cases: snapshot.examples.filter((e) => e.surfaces.includes('cases')),
+  };
+}
+
+const TOOL_TO_VERB: Record<string, string> = {
+  search_memories: 'remembered',
+  perplexity_search: 'searched',
+  add_memory: 'noted',
+  final_result: 'settled',
+  fetch_url: 'read',
+  google_search: 'searched',
+  web_search: 'searched',
+};
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host.replace(/^www\./, '');
+  } catch {
+    return url;
+  }
+}
+
+function trimEvidence(text: string | undefined): string {
+  if (!text) return '';
+  const cleaned = text.replace(/\s+/g, ' ').trim();
+  if (cleaned.length <= 220) return cleaned;
+  const slice = cleaned.slice(0, 220);
+  const lastTerm = Math.max(slice.lastIndexOf('. '), slice.lastIndexOf('! '), slice.lastIndexOf('? '));
+  if (lastTerm > 80) return slice.slice(0, lastTerm + 1);
+  const lastSpace = slice.lastIndexOf(' ');
+  return slice.slice(0, lastSpace > 0 ? lastSpace : 220) + '…';
+}
+
+/**
+ * Merge a fresh execution into a baked snapshot entry. Mirrors the field
+ * extraction the build script does so live + baked entries have identical
+ * shape. Returns the original entry untouched if the live fetch yielded
+ * nothing useful.
+ */
+interface FeedExecutionLike {
+  task_id: string;
+  status?: string;
+  started_at?: string;
+  notification?: string;
+  result?: {
+    evidence?: string;
+    activity?: { tool?: string; detail?: string }[];
+    sources?: { url: string; title?: string }[];
+    grounding_sources?: { url: string; title?: string }[];
+  };
+  grounding_sources?: { url: string; title?: string }[];
+}
+
+function mergeExecution(
+  baked: LandingExampleSnapshot,
+  exec: FeedExecutionLike,
+): LandingExampleSnapshot {
+  const cfg = LANDING_EXAMPLES.find((c) => c.taskId === baked.taskId);
+  const liveEvidence = exec.result?.evidence || exec.notification || '';
+  const evidence = trimEvidence(cfg?.displayEvidenceOverride || liveEvidence) || baked.evidence;
+
+  const activity = (exec.result?.activity || [])
+    .filter((a) => a.tool)
+    .slice(0, 3)
+    .map((a) => ({
+      verb: TOOL_TO_VERB[a.tool || ''] || 'checked',
+      detail: (a.detail || '').replace(/\s+/g, ' ').trim().slice(0, 80),
+    }));
+
+  const sourceList = exec.result?.sources || exec.grounding_sources || exec.result?.grounding_sources || [];
+  const seen = new Set<string>();
+  const sources: string[] = [];
+  for (const s of sourceList) {
+    const h = hostOf(s.url);
+    if (h && !seen.has(h)) {
+      seen.add(h);
+      sources.push(h);
+      if (sources.length >= 3) break;
+    }
+  }
+
+  return {
+    ...baked,
+    startedAt: exec.started_at || baked.startedAt,
+    evidence,
+    activity: activity.length > 0 ? activity : baked.activity,
+    sources: sources.length > 0 ? sources : baked.sources,
+  };
+}
+
+export function LandingExamplesProvider({ children }: { children: ReactNode }) {
+  const [snapshot, setSnapshot] = useState<LandingSnapshot>(FALLBACK);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getPublicFeed(100)
+      .then((feed) => {
+        if (cancelled || !Array.isArray(feed)) return;
+        const latestByTask = new Map<string, FeedExecutionLike>();
+        for (const exec of feed as unknown as FeedExecutionLike[]) {
+          if (!exec?.task_id || exec.status !== 'success') continue;
+          const prior = latestByTask.get(exec.task_id);
+          if (!prior || new Date(exec.started_at || 0) > new Date(prior.started_at || 0)) {
+            latestByTask.set(exec.task_id, exec);
+          }
+        }
+        setSnapshot((prev) => ({
+          ...prev,
+          examples: prev.examples.map((entry) => {
+            const exec = latestByTask.get(entry.taskId);
+            return exec ? mergeExecution(entry, exec) : entry;
+          }),
+        }));
+      })
+      .catch(() => {
+        // Swallow: snapshot stays as the build-time fallback. The marketing
+        // page must never throw or render an error state.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const value = useMemo<LandingExamplesContextValue>(() => {
+    const { hero, cases } = partition(snapshot);
+    return { snapshot, hero, cases };
+  }, [snapshot]);
+
+  return <LandingExamplesContext.Provider value={value}>{children}</LandingExamplesContext.Provider>;
+}
+
+export function useLandingExamples(): LandingExamplesContextValue {
+  const ctx = useContext(LandingExamplesContext);
+  if (!ctx) {
+    // Defensive: components rendered outside the provider get the baked
+    // snapshot directly so first paint is still meaningful (e.g. for
+    // tests that render Hero in isolation).
+    const { hero, cases } = partition(FALLBACK);
+    return { snapshot: FALLBACK, hero, cases };
+  }
+  return ctx;
+}

--- a/frontend/src/contexts/LandingExamplesContext.tsx
+++ b/frontend/src/contexts/LandingExamplesContext.tsx
@@ -119,17 +119,18 @@ export function LandingExamplesProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (isPrerender()) return;
     let cancelled = false;
-    // Refresh both axes in parallel: feed → fresh evidence per watch,
-    // tasks → fresh total count for the "watching · N conditions" chip.
-    // Either can fail independently; merge whatever lands. Marketing
-    // route must never throw, so both promises catch into a no-op.
-    Promise.all([
-      api.getPublicFeed(100).catch(() => null),
-      api.getPublicTasks({ limit: 1 }).catch(() => null),
-    ]).then(([feed, tasksData]) => {
-      if (cancelled) return;
-      const latestByTask = new Map<string, FeedExecutionLike>();
-      if (Array.isArray(feed)) {
+    // Only refresh the per-watch evidence here. We deliberately do NOT
+    // refresh `totalPublicConditions` post-hydration: the bake is
+    // cross-env (always reads the prod public feed at build, see
+    // sync-landing-examples.mjs), but the runtime API client uses
+    // window.CONFIG.apiUrl — which on staging points at api-staging
+    // (0 public tasks) and would clobber the prod-baked count to 0 on
+    // first interaction. The count chip stays baked-fresh per deploy.
+    api
+      .getPublicFeed(100)
+      .then((feed) => {
+        if (cancelled || !Array.isArray(feed)) return;
+        const latestByTask = new Map<string, FeedExecutionLike>();
         for (const exec of feed as unknown as FeedExecutionLike[]) {
           if (!exec?.task_id || exec.status !== 'success') continue;
           const prior = latestByTask.get(exec.task_id);
@@ -137,16 +138,22 @@ export function LandingExamplesProvider({ children }: { children: ReactNode }) {
             latestByTask.set(exec.task_id, exec);
           }
         }
-      }
-      setSnapshot((prev) => ({
-        ...prev,
-        totalPublicConditions: tasksData?.total ?? prev.totalPublicConditions,
-        examples: prev.examples.map((entry) => {
-          const exec = latestByTask.get(entry.taskId);
-          return exec ? mergeExecution(entry, exec) : entry;
-        }),
-      }));
-    });
+        // Skip the setState if no curated taskId got a live execution —
+        // avoids an identity-change re-render that re-arms Hero's cycle
+        // effect for nothing.
+        if (latestByTask.size === 0) return;
+        setSnapshot((prev) => ({
+          ...prev,
+          examples: prev.examples.map((entry) => {
+            const exec = latestByTask.get(entry.taskId);
+            return exec ? mergeExecution(entry, exec) : entry;
+          }),
+        }));
+      })
+      .catch(() => {
+        // Swallow: snapshot stays as the build-time fallback. The
+        // marketing route must never throw or render an error state.
+      });
     return () => {
       cancelled = true;
     };

--- a/frontend/src/contexts/LandingExamplesContext.tsx
+++ b/frontend/src/contexts/LandingExamplesContext.tsx
@@ -6,16 +6,24 @@
 // React first paint structurally identical, avoiding hydration mismatches.
 //
 // Post-hydration: the provider fires a single fetch against
-// /api/v1/public/feed and merges fresher executions into the in-memory
-// snapshot keyed by taskId. Both Hero (rotation) and Cases (Receipts)
-// read from this context so a rogue task on /explore can't surface twice.
+// /api/v1/public/feed (+ /api/v1/public/tasks for the live count) and
+// merges fresher executions into the in-memory snapshot keyed by taskId.
+// Both Hero (rotation) and Cases (Receipts) read from this context so a
+// rogue task on /explore can't surface twice.
 
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { LANDING_EXAMPLES, type LandingSnapshot, type LandingExampleSnapshot } from '@/data/landingExamples';
 import fallbackJson from '@/data/landingExamples.fallback.json';
+import { hostOf, paraphraseTool, trimEvidence } from '@/utils/landingExamples';
 import { api } from '@/lib/api';
 
 const FALLBACK = fallbackJson as LandingSnapshot;
+
+// Build once at module init for O(1) lookup inside mergeExecution (which
+// itself runs inside a map() loop). Was a .find() per merge — fine for 7
+// entries but cleaner this way and removes a future-scale footgun
+// (gemini #uN).
+const CONFIG_BY_ID = new Map(LANDING_EXAMPLES.map((cfg) => [cfg.taskId, cfg]));
 
 type ExampleBySurface = {
   hero: LandingExampleSnapshot[];
@@ -37,41 +45,17 @@ function partition(snapshot: LandingSnapshot): ExampleBySurface {
   };
 }
 
-const TOOL_TO_VERB: Record<string, string> = {
-  search_memories: 'remembered',
-  perplexity_search: 'searched',
-  add_memory: 'noted',
-  final_result: 'settled',
-  fetch_url: 'read',
-  google_search: 'searched',
-  web_search: 'searched',
-};
-
-function hostOf(url: string): string {
-  try {
-    return new URL(url).host.replace(/^www\./, '');
-  } catch {
-    return url;
-  }
-}
-
-function trimEvidence(text: string | undefined): string {
-  if (!text) return '';
-  const cleaned = text.replace(/\s+/g, ' ').trim();
-  if (cleaned.length <= 220) return cleaned;
-  const slice = cleaned.slice(0, 220);
-  const lastTerm = Math.max(slice.lastIndexOf('. '), slice.lastIndexOf('! '), slice.lastIndexOf('? '));
-  if (lastTerm > 80) return slice.slice(0, lastTerm + 1);
-  const lastSpace = slice.lastIndexOf(' ');
-  return slice.slice(0, lastSpace > 0 ? lastSpace : 220) + '…';
-}
-
 /**
- * Merge a fresh execution into a baked snapshot entry. Mirrors the field
- * extraction the build script does so live + baked entries have identical
- * shape. Returns the original entry untouched if the live fetch yielded
- * nothing useful.
+ * Inside scripts/prerender.mjs Playwright sets window.__PRERENDER__ = true
+ * before navigating. Skip the runtime revalidation fetch under prerender
+ * so the captured HTML is always the build-time bake — no race between
+ * the in-flight fetch resolving and `page.content()` capturing.
  */
+function isPrerender(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.__PRERENDER__ === true;
+}
+
 interface FeedExecutionLike {
   task_id: string;
   status?: string;
@@ -86,11 +70,17 @@ interface FeedExecutionLike {
   grounding_sources?: { url: string; title?: string }[];
 }
 
+/**
+ * Merge a fresh execution into a baked snapshot entry. Mirrors the field
+ * extraction the build script does so live + baked entries have identical
+ * shape. Returns the baked entry untouched if the live fetch yielded
+ * nothing useful for a slot.
+ */
 function mergeExecution(
   baked: LandingExampleSnapshot,
   exec: FeedExecutionLike,
 ): LandingExampleSnapshot {
-  const cfg = LANDING_EXAMPLES.find((c) => c.taskId === baked.taskId);
+  const cfg = CONFIG_BY_ID.get(baked.taskId);
   const liveEvidence = exec.result?.evidence || exec.notification || '';
   const evidence = trimEvidence(cfg?.displayEvidenceOverride || liveEvidence) || baked.evidence;
 
@@ -98,7 +88,7 @@ function mergeExecution(
     .filter((a) => a.tool)
     .slice(0, 3)
     .map((a) => ({
-      verb: TOOL_TO_VERB[a.tool || ''] || 'checked',
+      verb: paraphraseTool(a.tool),
       detail: (a.detail || '').replace(/\s+/g, ' ').trim().slice(0, 80),
     }));
 
@@ -106,7 +96,7 @@ function mergeExecution(
   const seen = new Set<string>();
   const sources: string[] = [];
   for (const s of sourceList) {
-    const h = hostOf(s.url);
+    const h = hostOf(s);
     if (h && !seen.has(h)) {
       seen.add(h);
       sources.push(h);
@@ -123,28 +113,23 @@ function mergeExecution(
   };
 }
 
-/**
- * Inside scripts/prerender.mjs Playwright sets window.__PRERENDER__ = true
- * before navigating. Skip the runtime revalidation fetch under prerender
- * so the captured HTML is always the build-time bake — no race between
- * the in-flight fetch resolving and `page.content()` capturing.
- */
-function isPrerender(): boolean {
-  if (typeof window === 'undefined') return false;
-  return window.__PRERENDER__ === true;
-}
-
 export function LandingExamplesProvider({ children }: { children: ReactNode }) {
   const [snapshot, setSnapshot] = useState<LandingSnapshot>(FALLBACK);
 
   useEffect(() => {
     if (isPrerender()) return;
     let cancelled = false;
-    api
-      .getPublicFeed(100)
-      .then((feed) => {
-        if (cancelled || !Array.isArray(feed)) return;
-        const latestByTask = new Map<string, FeedExecutionLike>();
+    // Refresh both axes in parallel: feed → fresh evidence per watch,
+    // tasks → fresh total count for the "watching · N conditions" chip.
+    // Either can fail independently; merge whatever lands. Marketing
+    // route must never throw, so both promises catch into a no-op.
+    Promise.all([
+      api.getPublicFeed(100).catch(() => null),
+      api.getPublicTasks({ limit: 1 }).catch(() => null),
+    ]).then(([feed, tasksData]) => {
+      if (cancelled) return;
+      const latestByTask = new Map<string, FeedExecutionLike>();
+      if (Array.isArray(feed)) {
         for (const exec of feed as unknown as FeedExecutionLike[]) {
           if (!exec?.task_id || exec.status !== 'success') continue;
           const prior = latestByTask.get(exec.task_id);
@@ -152,18 +137,16 @@ export function LandingExamplesProvider({ children }: { children: ReactNode }) {
             latestByTask.set(exec.task_id, exec);
           }
         }
-        setSnapshot((prev) => ({
-          ...prev,
-          examples: prev.examples.map((entry) => {
-            const exec = latestByTask.get(entry.taskId);
-            return exec ? mergeExecution(entry, exec) : entry;
-          }),
-        }));
-      })
-      .catch(() => {
-        // Swallow: snapshot stays as the build-time fallback. The marketing
-        // page must never throw or render an error state.
-      });
+      }
+      setSnapshot((prev) => ({
+        ...prev,
+        totalPublicConditions: tasksData?.total ?? prev.totalPublicConditions,
+        examples: prev.examples.map((entry) => {
+          const exec = latestByTask.get(entry.taskId);
+          return exec ? mergeExecution(entry, exec) : entry;
+        }),
+      }));
+    });
     return () => {
       cancelled = true;
     };

--- a/frontend/src/data/landingExamples.fallback.json
+++ b/frontend/src/data/landingExamples.fallback.json
@@ -1,6 +1,6 @@
 {
   "totalPublicConditions": 7,
-  "syncedAt": "2026-05-10T19:21:31.371Z",
+  "syncedAt": "2026-05-10T19:25:14.060Z",
   "examples": [
     {
       "taskId": "cfbf0275-77df-4fc2-adbe-c5fb7a6e8e38",

--- a/frontend/src/data/landingExamples.fallback.json
+++ b/frontend/src/data/landingExamples.fallback.json
@@ -1,0 +1,211 @@
+{
+  "totalPublicConditions": 7,
+  "syncedAt": "2026-05-10T14:15:10.894Z",
+  "examples": [
+    {
+      "taskId": "cfbf0275-77df-4fc2-adbe-c5fb7a6e8e38",
+      "displayPrompt": "Tell me how the multi-agent coding ecosystem is evolving.",
+      "tag": "frontier · ai",
+      "surfaces": [
+        "hero"
+      ],
+      "startedAt": "2026-05-10T13:13:59.361938Z",
+      "state": "active",
+      "evidence": "The multi-agent coding landscape as of May 2026 has converged into three primary layers: 1) Productized harnesses (Claude Code, Cursor) that ship with the agent loop fused in; 2) Orchestration frameworks (LangGraph,…",
+      "sources": [
+        "resources.anthropic.com",
+        "blog.sshh.io",
+        "thenuancedperspective.substack.com"
+      ],
+      "activity": [
+        {
+          "verb": "remembered",
+          "detail": "multi-agent systems coding agent harnesses"
+        },
+        {
+          "verb": "searched",
+          "detail": "developments in multi-agent systems for coding agent harnesses 2026"
+        },
+        {
+          "verb": "checked",
+          "detail": "multi-agent frameworks for autonomous software engineering 2026"
+        }
+      ]
+    },
+    {
+      "taskId": "bac2f3ac-2c7e-43a8-955b-3386303620a7",
+      "displayPrompt": "Tell me what's new in East London saunas.",
+      "tag": "lifestyle · london",
+      "surfaces": [
+        "hero"
+      ],
+      "startedAt": "2026-05-01T10:00:00.283383Z",
+      "state": "active",
+      "evidence": "Researched current sauna offerings in East London. Confirmed that established venues (Rooftop Saunas, Community Sauna Baths, Arc, etc.) remain popular.",
+      "sources": [
+        "timeout.com",
+        "secretldn.com",
+        "thesaunaguide.co.uk"
+      ],
+      "activity": [
+        {
+          "verb": "remembered",
+          "detail": "saunas in east London"
+        },
+        {
+          "verb": "checked",
+          "detail": "new sauna openings East London May 2026"
+        },
+        {
+          "verb": "noted",
+          "detail": "The East London sauna market is rapidly growing. Key development to watch: Sea L"
+        }
+      ]
+    },
+    {
+      "taskId": "33f03646-4097-4861-8aa8-0152f4808d5b",
+      "displayPrompt": "Tell me when public sentiment toward OpenAI shifts.",
+      "tag": "sentiment · ai",
+      "surfaces": [
+        "hero"
+      ],
+      "startedAt": "2026-05-09T10:00:00.105617Z",
+      "state": "active",
+      "evidence": "The Musk v. OpenAI trial continues to be the primary driver of sentiment. Recent testimony from former board member Helen Toner and former CTO Mira Murati has intensified criticism of Sam Altman's leadership,…",
+      "sources": [
+        "indiatoday.in",
+        "youtube.com",
+        "faegredrinker.com"
+      ],
+      "activity": [
+        {
+          "verb": "searched",
+          "detail": "latest news OpenAI public sentiment May 2026 trial"
+        },
+        {
+          "verb": "checked",
+          "detail": "\"OpenAI\" sentiment OR \"Sam Altman\" -is:retweet -min_faves:50"
+        },
+        {
+          "verb": "noted",
+          "detail": "The OpenAI sentiment remains persistently negative, driven by ongoing trial test"
+        }
+      ]
+    },
+    {
+      "taskId": "197d62ff-b605-40eb-92f1-7b6018cf1ae6",
+      "displayPrompt": "Tell me when a major open-weight model is released.",
+      "tag": "open-source · ai",
+      "surfaces": [
+        "hero"
+      ],
+      "startedAt": "2026-03-11T09:45:29.116048Z",
+      "state": "active",
+      "evidence": "Since March 10, 2026, there has been a flurry of significant open-source/open-weight LLM releases. The key findings from April 2026 updates include: 1.",
+      "sources": [
+        "llm-stats.com",
+        "fazm.ai",
+        "till-freitag.com"
+      ],
+      "activity": [
+        {
+          "verb": "remembered",
+          "detail": "open source LLM release search strategy"
+        },
+        {
+          "verb": "searched",
+          "detail": "open source LLM releases after March 10, 2026"
+        },
+        {
+          "verb": "noted",
+          "detail": "For tracking open-source LLM releases, LLM Stats (llm-stats.com/llm-updates) is "
+        }
+      ]
+    },
+    {
+      "taskId": "d74456cd-e9cf-40d7-acb8-2a1606a55f4c",
+      "displayPrompt": "Tell me when webwhen ships a new feature.",
+      "tag": "self · changelog",
+      "surfaces": [
+        "hero"
+      ],
+      "startedAt": "2026-05-07T08:00:00.224441Z",
+      "state": "active",
+      "evidence": "The official changelog for the platform (https://torale.ai/changelog) shows that as of May 5, 2026, the service has rebranded from Torale to webwhen.",
+      "sources": [
+        "torale.ai"
+      ],
+      "activity": [
+        {
+          "verb": "remembered",
+          "detail": "torale.ai changelog monitoring strategy"
+        },
+        {
+          "verb": "read",
+          "detail": "https://torale.ai/changelog"
+        },
+        {
+          "verb": "noted",
+          "detail": "The platform formerly known as Torale.ai has rebranded to webwhen, effective May"
+        }
+      ]
+    },
+    {
+      "taskId": "14d7792c-7b77-4781-8f85-d4980e631e43",
+      "displayPrompt": "Tell me when a frontier AI lab releases a new model.",
+      "tag": "frontier · ai",
+      "surfaces": [
+        "cases"
+      ],
+      "startedAt": "2026-04-23T16:00:00.112106Z",
+      "state": "completed",
+      "evidence": "Since the last check on April 16, 2026, OpenAI has released a significant update to its image generation capabilities within ChatGPT. No new model releases were found from DeepMind, Anthropic, or xAI in this timeframe.",
+      "sources": [
+        "releasebot.io"
+      ],
+      "activity": [
+        {
+          "verb": "remembered",
+          "detail": "AI model release monitoring strategy"
+        },
+        {
+          "verb": "searched",
+          "detail": "AI model releases OpenAI Anthropic DeepMind xAI after April 16 2026"
+        },
+        {
+          "verb": "noted",
+          "detail": "OpenAI updates ChatGPT capabilities frequently (e.g., image generation model rel"
+        }
+      ]
+    },
+    {
+      "taskId": "369e9794-8971-4a21-be64-b9f18009ec55",
+      "displayPrompt": "Tell me when Claude Code developer sentiment shifts.",
+      "tag": "sentiment · devtools",
+      "surfaces": [
+        "cases"
+      ],
+      "startedAt": "2026-04-26T12:00:00.415000Z",
+      "state": "completed",
+      "evidence": "Anthropic has formally acknowledged and resolved the performance regressions (laziness, forgetfulness, and rapid usage limit depletion) that were negatively affecting Claude Code.",
+      "sources": [
+        "anthropic.com",
+        "code.claude.com"
+      ],
+      "activity": [
+        {
+          "verb": "remembered",
+          "detail": "Claude Code sentiment"
+        },
+        {
+          "verb": "searched",
+          "detail": "Claude Code developer sentiment April 2026 updates v2.1.111+ performance stabili"
+        },
+        {
+          "verb": "noted",
+          "detail": "Anthropic has formally addressed performance degradation concerns (laziness, for"
+        }
+      ]
+    }
+  ]
+}

--- a/frontend/src/data/landingExamples.fallback.json
+++ b/frontend/src/data/landingExamples.fallback.json
@@ -1,10 +1,10 @@
 {
-  "totalPublicConditions": 7,
-  "syncedAt": "2026-05-10T19:25:14.060Z",
+  "totalPublicConditions": 9,
+  "syncedAt": "2026-05-10T20:10:56.584Z",
   "examples": [
     {
       "taskId": "cfbf0275-77df-4fc2-adbe-c5fb7a6e8e38",
-      "displayPrompt": "Tell me how the multi-agent coding ecosystem is evolving.",
+      "displayPrompt": "the multi-agent coding ecosystem",
       "tag": "frontier · ai",
       "surfaces": [
         "hero"
@@ -34,7 +34,7 @@
     },
     {
       "taskId": "bac2f3ac-2c7e-43a8-955b-3386303620a7",
-      "displayPrompt": "Tell me what's new in East London saunas.",
+      "displayPrompt": "what's new in East London saunas",
       "tag": "lifestyle · london",
       "surfaces": [
         "hero"
@@ -64,7 +64,7 @@
     },
     {
       "taskId": "33f03646-4097-4861-8aa8-0152f4808d5b",
-      "displayPrompt": "Tell me when public sentiment toward OpenAI shifts.",
+      "displayPrompt": "public sentiment toward OpenAI",
       "tag": "sentiment · ai",
       "surfaces": [
         "hero"
@@ -94,7 +94,7 @@
     },
     {
       "taskId": "197d62ff-b605-40eb-92f1-7b6018cf1ae6",
-      "displayPrompt": "Tell me when a major open-weight model is released.",
+      "displayPrompt": "open-weight model releases",
       "tag": "open-source · ai",
       "surfaces": [
         "hero"
@@ -124,7 +124,7 @@
     },
     {
       "taskId": "d74456cd-e9cf-40d7-acb8-2a1606a55f4c",
-      "displayPrompt": "Tell me when webwhen ships a new feature.",
+      "displayPrompt": "new features shipped by webwhen",
       "tag": "self · changelog",
       "surfaces": [
         "hero"
@@ -152,7 +152,7 @@
     },
     {
       "taskId": "14d7792c-7b77-4781-8f85-d4980e631e43",
-      "displayPrompt": "Tell me when a frontier AI lab releases a new model.",
+      "displayPrompt": "frontier AI lab model releases",
       "tag": "frontier · ai",
       "surfaces": [
         "cases"
@@ -180,7 +180,7 @@
     },
     {
       "taskId": "369e9794-8971-4a21-be64-b9f18009ec55",
-      "displayPrompt": "Tell me when Claude Code developer sentiment shifts.",
+      "displayPrompt": "Claude Code developer sentiment",
       "tag": "sentiment · devtools",
       "surfaces": [
         "cases"
@@ -204,6 +204,34 @@
         {
           "verb": "noted",
           "detail": "Anthropic has formally addressed performance degradation concerns (laziness, for"
+        }
+      ]
+    },
+    {
+      "taskId": "62f9774b-ccab-4d28-b5de-bb12f97339f2",
+      "displayPrompt": "recent funding rounds for YC-backed companies",
+      "tag": "funding · yc",
+      "surfaces": [
+        "cases"
+      ],
+      "startedAt": "2026-05-10T20:04:11.696558Z",
+      "state": "active",
+      "evidence": "Searched for recent funding rounds involving YC-backed startups. Found multiple recent funding events from May 2026, including Corvera, which raised $4.2 million in seed funding, and Hightouch, which raised $150…",
+      "sources": [
+        "thefashionlaw.com"
+      ],
+      "activity": [
+        {
+          "verb": "searched",
+          "detail": "recent funding rounds YC backed companies May 2026"
+        },
+        {
+          "verb": "noted",
+          "detail": "Y Combinator funding news can be reliably found in recent tech news trackers lik"
+        },
+        {
+          "verb": "settled",
+          "detail": ""
         }
       ]
     }

--- a/frontend/src/data/landingExamples.fallback.json
+++ b/frontend/src/data/landingExamples.fallback.json
@@ -1,6 +1,6 @@
 {
   "totalPublicConditions": 7,
-  "syncedAt": "2026-05-10T14:15:10.894Z",
+  "syncedAt": "2026-05-10T19:21:31.371Z",
   "examples": [
     {
       "taskId": "cfbf0275-77df-4fc2-adbe-c5fb7a6e8e38",

--- a/frontend/src/data/landingExamples.ts
+++ b/frontend/src/data/landingExamples.ts
@@ -1,0 +1,133 @@
+// Curated set of public watches surfaced on the marketing landing page.
+//
+// `taskId` references a row in /api/v1/public/tasks. The build-time script
+// scripts/sync-landing-examples.mjs joins each entry with the latest
+// successful execution from /api/v1/public/feed and writes the result to
+// .landing-examples-snapshot.json, which prerender bakes into dist/index.html.
+//
+// At runtime, LandingExamplesContext reads the snapshot for first paint and
+// re-fetches /api/v1/public/feed once after hydration to refresh evidence.
+//
+// `surfaces` controls which surface a watch lands on:
+//   'hero'   — composer rotation in the landing hero (cycles every 4.5s)
+//   'cases'  — three editorial Receipts cards mid-page
+//
+// Hero and cases sets are deliberately disjoint here so the page reads as
+// breadth (hero cycle) followed by depth (Receipts).
+//
+// `displayPrompt` overrides the raw task name with imperative-voice copy
+// fit for the composer ("Tell me when X..."). The real task names are
+// noun-phrases ("Frontier AI Model Releases") and don't read in-character.
+
+export type LandingExampleSurface = 'hero' | 'cases';
+
+export interface LandingExampleConfig {
+  /** Public task id (UUID). */
+  taskId: string;
+  /** Imperative-voice prompt rendered in the composer. */
+  displayPrompt: string;
+  /** Eyebrow tag rendered above the prompt; mono, dot-separated. */
+  tag: string;
+  /** Which surfaces this watch appears on. */
+  surfaces: LandingExampleSurface[];
+  /**
+   * Pin a known-good evidence sentence for this watch. Used when the live
+   * evidence text is too long, off-tone, or risks reading as embarrassing
+   * on a marketing surface. When set, the snapshot script ignores the live
+   * evidence and bakes this string instead.
+   */
+  displayEvidenceOverride?: string;
+}
+
+export const LANDING_EXAMPLES: LandingExampleConfig[] = [
+  // === Hero rotation =================================================
+  // Five evergreen-shaped watches that span category. Cycle order is
+  // fixed; first entry renders at first paint to keep prerender HTML
+  // deterministic and avoid hydration mismatch.
+  {
+    taskId: 'cfbf0275-77df-4fc2-adbe-c5fb7a6e8e38',
+    displayPrompt: 'Tell me how the multi-agent coding ecosystem is evolving.',
+    tag: 'frontier · ai',
+    surfaces: ['hero'],
+  },
+  {
+    taskId: 'bac2f3ac-2c7e-43a8-955b-3386303620a7',
+    displayPrompt: "Tell me what's new in East London saunas.",
+    tag: 'lifestyle · london',
+    surfaces: ['hero'],
+  },
+  {
+    taskId: '33f03646-4097-4861-8aa8-0152f4808d5b',
+    displayPrompt: 'Tell me when public sentiment toward OpenAI shifts.',
+    tag: 'sentiment · ai',
+    surfaces: ['hero'],
+  },
+  {
+    taskId: '197d62ff-b605-40eb-92f1-7b6018cf1ae6',
+    displayPrompt: 'Tell me when a major open-weight model is released.',
+    tag: 'open-source · ai',
+    surfaces: ['hero'],
+  },
+  {
+    taskId: 'd74456cd-e9cf-40d7-acb8-2a1606a55f4c',
+    displayPrompt: 'Tell me when webwhen ships a new feature.',
+    tag: 'self · changelog',
+    surfaces: ['hero'],
+  },
+
+  // === Receipts cards ================================================
+  // Three watches deliberately not in the hero rotation. Hand-picked
+  // so the page reads as breadth (hero cycle) → depth (Receipts).
+  {
+    taskId: '14d7792c-7b77-4781-8f85-d4980e631e43',
+    displayPrompt: 'Tell me when a frontier AI lab releases a new model.',
+    tag: 'frontier · ai',
+    surfaces: ['cases'],
+  },
+  {
+    taskId: '369e9794-8971-4a21-be64-b9f18009ec55',
+    displayPrompt: 'Tell me when Claude Code developer sentiment shifts.',
+    tag: 'sentiment · devtools',
+    surfaces: ['cases'],
+  },
+];
+
+// Note: there are currently 7 public watches and we use 7 here (5 hero,
+// 2 cases). The third Receipts card slot is intentionally empty until
+// another high-quality public watch lands; Cases.tsx renders only the
+// entries it finds rather than padding with invented copy.
+
+// === Snapshot shape ===================================================
+//
+// Written to .landing-examples-snapshot.json by the prebuild script and
+// read at module init by LandingExamplesContext. Mirrors the shape the
+// runtime fetch produces, so snapshot-vs-live merging is a simple keyed
+// merge by taskId.
+
+export interface LandingExampleSnapshot {
+  taskId: string;
+  displayPrompt: string;
+  tag: string;
+  surfaces: LandingExampleSurface[];
+  /** ISO timestamp of the latest execution. Empty if no executions found. */
+  startedAt: string;
+  /** Real task state at last sync. 'completed' shows ember dot. */
+  state: 'active' | 'completed' | 'paused' | 'failed' | 'unknown';
+  /** Trimmed evidence sentence. Italic-serif pull-quote on Receipts cards. */
+  evidence: string;
+  /** Top-3 source hosts (e.g. ['anthropic.com', 'openai.com']). */
+  sources: string[];
+  /**
+   * Editorial paraphrase of the agent's tool sequence, per execution.
+   * Three lines, terse verbs. Hero composer log.
+   */
+  activity: { verb: string; detail: string }[];
+}
+
+export interface LandingSnapshot {
+  /** Total public watches running across all users. Powers the live counter. */
+  totalPublicConditions: number;
+  /** ISO timestamp the snapshot was generated. */
+  syncedAt: string;
+  examples: LandingExampleSnapshot[];
+}

--- a/frontend/src/data/landingExamples.ts
+++ b/frontend/src/data/landingExamples.ts
@@ -3,7 +3,8 @@
 // `taskId` references a row in /api/v1/public/tasks. The build-time script
 // scripts/sync-landing-examples.mjs joins each entry with the latest
 // successful execution from /api/v1/public/feed and writes the result to
-// .landing-examples-snapshot.json, which prerender bakes into dist/index.html.
+// src/data/landingExamples.fallback.json (the file the React tree imports),
+// which prerender bakes into dist/index.html.
 //
 // At runtime, LandingExamplesContext reads the snapshot for first paint and
 // re-fetches /api/v1/public/feed once after hydration to refresh evidence.
@@ -15,16 +16,17 @@
 // Hero and cases sets are deliberately disjoint here so the page reads as
 // breadth (hero cycle) followed by depth (Receipts).
 //
-// `displayPrompt` overrides the raw task name with imperative-voice copy
-// fit for the composer ("Tell me when X..."). The real task names are
-// noun-phrases ("Frontier AI Model Releases") and don't read in-character.
+// `displayPrompt` is the bare topic the watch tracks. The composer chrome
+// already says "new watch · plain english · no rules" so the prompt itself
+// doesn't need an imperative wrapper. Lowercase sentence-style without
+// trailing period, matching the "Topic of the watch" register.
 
 export type LandingExampleSurface = 'hero' | 'cases';
 
 export interface LandingExampleConfig {
   /** Public task id (UUID). */
   taskId: string;
-  /** Imperative-voice prompt rendered in the composer. */
+  /** Bare topic shown inside the composer. No "Tell me X" prefix, no period. */
   displayPrompt: string;
   /** Eyebrow tag rendered above the prompt; mono, dot-separated. */
   tag: string;
@@ -46,63 +48,83 @@ export const LANDING_EXAMPLES: LandingExampleConfig[] = [
   // deterministic and avoid hydration mismatch.
   {
     taskId: 'cfbf0275-77df-4fc2-adbe-c5fb7a6e8e38',
-    displayPrompt: 'Tell me how the multi-agent coding ecosystem is evolving.',
+    displayPrompt: 'the multi-agent coding ecosystem',
     tag: 'frontier · ai',
     surfaces: ['hero'],
   },
   {
     taskId: 'bac2f3ac-2c7e-43a8-955b-3386303620a7',
-    displayPrompt: "Tell me what's new in East London saunas.",
+    displayPrompt: "what's new in East London saunas",
     tag: 'lifestyle · london',
     surfaces: ['hero'],
   },
   {
     taskId: '33f03646-4097-4861-8aa8-0152f4808d5b',
-    displayPrompt: 'Tell me when public sentiment toward OpenAI shifts.',
+    displayPrompt: 'public sentiment toward OpenAI',
     tag: 'sentiment · ai',
     surfaces: ['hero'],
   },
   {
     taskId: '197d62ff-b605-40eb-92f1-7b6018cf1ae6',
-    displayPrompt: 'Tell me when a major open-weight model is released.',
+    displayPrompt: 'open-weight model releases',
     tag: 'open-source · ai',
     surfaces: ['hero'],
   },
   {
     taskId: 'd74456cd-e9cf-40d7-acb8-2a1606a55f4c',
-    displayPrompt: 'Tell me when webwhen ships a new feature.',
+    displayPrompt: 'new features shipped by webwhen',
     tag: 'self · changelog',
     surfaces: ['hero'],
   },
 
   // === Receipts cards ================================================
-  // Three watches deliberately not in the hero rotation. Hand-picked
-  // so the page reads as breadth (hero cycle) → depth (Receipts).
+  // Three watches deliberately not in the hero rotation: two settled
+  // (showing the agent retiring a watch) and one currently watching
+  // (showing the agent actively reading the web).
   {
     taskId: '14d7792c-7b77-4781-8f85-d4980e631e43',
-    displayPrompt: 'Tell me when a frontier AI lab releases a new model.',
+    displayPrompt: 'frontier AI lab model releases',
     tag: 'frontier · ai',
     surfaces: ['cases'],
   },
   {
     taskId: '369e9794-8971-4a21-be64-b9f18009ec55',
-    displayPrompt: 'Tell me when Claude Code developer sentiment shifts.',
+    displayPrompt: 'Claude Code developer sentiment',
     tag: 'sentiment · devtools',
     surfaces: ['cases'],
   },
-];
+  {
+    taskId: '62f9774b-ccab-4d28-b5de-bb12f97339f2',
+    displayPrompt: 'recent funding rounds for YC-backed companies',
+    tag: 'funding · yc',
+    surfaces: ['cases'],
+  },
 
-// Note: there are currently 7 public watches and we use 7 here (5 hero,
-// 2 cases). The third Receipts card slot is intentionally empty until
-// another high-quality public watch lands; Cases.tsx renders only the
-// entries it finds rather than padding with invented copy.
+  // === Parked ========================================================
+  // Public watches kept here for future rotation. Left out of `surfaces`
+  // either because they don't yet have rich enough evidence or because
+  // the curated slate is already full. To enable, add a surface and
+  // redeploy.
+  // {
+  //   taskId: 'c3f20127-7319-49e1-b78a-d3767895c480',
+  //   displayPrompt: 'European Central Bank rate decisions',
+  //   tag: 'regulatory · finance',
+  //   surfaces: [],
+  // },
+  // {
+  //   taskId: '9302833f-2e54-4f2b-97dd-3a256e39603b',
+  //   displayPrompt: 'YC dev-tools Series A raises',
+  //   tag: 'funding · devtools',
+  //   surfaces: [],
+  // },
+];
 
 // === Snapshot shape ===================================================
 //
-// Written to .landing-examples-snapshot.json by the prebuild script and
-// read at module init by LandingExamplesContext. Mirrors the shape the
-// runtime fetch produces, so snapshot-vs-live merging is a simple keyed
-// merge by taskId.
+// Written to src/data/landingExamples.fallback.json by the prebuild
+// script and read at module init by LandingExamplesContext. Mirrors the
+// shape the runtime fetch produces, so snapshot-vs-live merging is a
+// simple keyed merge by taskId.
 
 export interface LandingExampleSnapshot {
   taskId: string;

--- a/frontend/src/utils/landingExamples.ts
+++ b/frontend/src/utils/landingExamples.ts
@@ -1,0 +1,57 @@
+// Helpers shared between the build-time snapshot script and the runtime
+// LandingExamplesContext. Source of truth for tool→verb paraphrasing,
+// host extraction, and evidence trimming. Keeping these here avoids the
+// drift risk gemini flagged when the same constants lived in both
+// scripts/sync-landing-examples.mjs (Node) and the React context (TS).
+//
+// This file is .ts so the React side gets types; the Node build script
+// loads it via the existing esbuild-backed loadTsModule() helper.
+
+/** Editorial paraphrase of the agent's tool sequence. */
+export const TOOL_TO_VERB: Record<string, string> = {
+  search_memories: 'remembered',
+  perplexity_search: 'searched',
+  add_memory: 'noted',
+  final_result: 'settled',
+  fetch_url: 'read',
+  google_search: 'searched',
+  web_search: 'searched',
+};
+
+export function paraphraseTool(tool: string | undefined): string {
+  return TOOL_TO_VERB[tool ?? ''] || 'checked';
+}
+
+/**
+ * Extract the host from a source entry. Accepts either `{url, title}`
+ * objects (the documented feed shape) or bare URL strings (defensive
+ * shim per gemini's #uR catch — if the API ever flattens its sources
+ * shape, callers don't break).
+ */
+export function hostOf(source: string | { url?: string } | null | undefined): string {
+  if (!source) return '';
+  const raw = typeof source === 'string' ? source : source.url;
+  if (!raw) return '';
+  try {
+    return new URL(raw).host.replace(/^www\./, '');
+  } catch {
+    return raw;
+  }
+}
+
+/**
+ * Trim evidence to a single sentence inside a 220-char budget. Prefers a
+ * sentence-terminator break; falls back to soft truncation at the last
+ * space with an ellipsis. Matches the build-time and runtime shape so a
+ * post-hydration refresh swaps in a string of comparable length.
+ */
+export function trimEvidence(text: string | null | undefined): string {
+  if (!text) return '';
+  const cleaned = text.replace(/\s+/g, ' ').trim();
+  if (cleaned.length <= 220) return cleaned;
+  const slice = cleaned.slice(0, 220);
+  const lastTerm = Math.max(slice.lastIndexOf('. '), slice.lastIndexOf('! '), slice.lastIndexOf('? '));
+  if (lastTerm > 80) return slice.slice(0, lastTerm + 1);
+  const lastSpace = slice.lastIndexOf(' ');
+  return slice.slice(0, lastSpace > 0 ? lastSpace : 220) + '…';
+}


### PR DESCRIPTION
## Summary

Replaces the static PS5/iPhone/Linear examples on the marketing landing with real public watches sourced from `/api/v1/public/feed`. Hero composer cycles through 5 evergreen watches with a typewriter transition between cycles; Receipts (eyebrow swap from "Use cases") shows editorial cards with the agent's actual evidence prose in italic-serif pull-quote register.

## Shape

- New `frontend/src/data/landingExamples.ts` curates which `task_id`s land on which surface, with `displayPrompt` overrides and an optional `displayEvidenceOverride` valve for embarrassing live evidence.
- New `frontend/scripts/sync-landing-examples.mjs` runs in `prebuild`, fetches the feed, joins with the curated config, writes `src/data/landingExamples.fallback.json` directly (the file the React tree imports). On fetch failure the committed JSON stays put as the last-known-good fallback. Same dual-role pattern as `sync-changelog-fixture.mjs`. 15s `AbortController` timeout so a sleepy API can't stretch image builds.
- New `frontend/src/contexts/LandingExamplesContext.tsx` reads the baked snapshot at module init for first paint, then fires a single `getPublicFeed()` post-hydration to refresh evidence in place. Keyed merge by `task_id`, per-entry fallback if a `task_id` resolves to no execution. Failure-silent. Both Hero's typewriter and the provider's revalidation gate on `window.__PRERENDER__` so nothing mutates during Playwright capture.
- Hero log lines paraphrase the agent's tool sequence (`perplexity_search → searched`, `add_memory → noted`, `final_result → settled`). Verbs map ~5 entries; unmapped tools fall back to `checked`.
- Hero typewriter: state machine `idle (3s) → deleting (18ms/char) → typing (28ms/char) → idle`. Cursor swaps from ember-blink (idle, "ready") to steady ink-3 (typing/deleting, "working") and back. `aria-hidden` on the animated text; sr-only mirror with `aria-live="polite"` carries the settled prompt to screen readers once per cycle.
- Receipts cards: italic Instrument Serif pull-quote on real `evidence`, top-3 source hosts, `settled` (ember dot) / `watching` (ink-3 dot) state line, absolute date.

## Build-time data flow

The marketing snapshot is **brand-curated content**, not staging-fidelity content. Both staging and production builds bake from the production public feed. Reasoning:

- The thesis "real watches power the page" only holds if the watches actually exist. Staging-API has zero public watches; baking from staging would render the hero empty.
- Marketing data is brand-curated cross-env. Same single-source pattern as the changelog fixture (no per-env split).
- `LANDING_EXAMPLES_API_ORIGIN` env var is preserved as the override mechanism for local dev / forks. No string-replace heuristics.

## Hydration safety

- First paint = `LANDING_EXAMPLES[surfaces='hero'][0]` deterministically; cycle starts in `useEffect` only.
- Both the typewriter and the provider revalidation skip when `window.__PRERENDER__ === true` so Playwright captures stable HTML regardless of settle time.
- Dates rendered absolute (`May 9`), no relative-time strings on the SSR/CSR boundary.
- Live counter (`watching · N conditions`) baked from snapshot, post-hydration update mutates value not structure.
- Build verified: 11 routes prerendered cleanly, no new hydration warnings vs main.

## SEO

- Crawlers index the build-time snapshot (real evidence prose, real source hosts). Post-hydration revalidation only refreshes values within the same DOM shape; no cloaking risk.
- Same prerender pattern as `/changelog` — proven precedent.
- OG/Twitter metadata stays static via `DynamicMeta`. No schema.org changes (Cases cards stay plain `<article>` — `Article`/`NewsArticle`/`DataFeed` would mismark them).

## Test plan

- [x] Apply `deploy` label to spin up staging; eyeball hero cycle + Receipts cards.
- [ ] Verify cycling pauses on hover, stops under `prefers-reduced-motion`.
- [ ] Confirm post-hydration fetch updates evidence (devtools network tab → `/api/v1/public/feed`).
- [ ] Sanity-check that the curated `displayPrompt` text and the live evidence prose read together as on-brand for each entry; pin `displayEvidenceOverride` if any read off.

## Notes for review

- Open call decision (per orchestrator's brief): hero log = editorial paraphrase of activity log, not trimmed evidence prose. Reasoning: separates concerns (hero terse-narrative, Receipts prose) and makes the agent's reasoning visible. One-file revert if you want the other shape.
- Receipts has 2 cards because the disjoint-with-hero set leaves 2 strong picks of 7 public watches. `Cases.tsx` renders only what it has rather than padding to 3; add another public watch and bump `surfaces: ['cases']` in `landingExamples.ts` to fill the slot.
- Codex review covered: build-time fetch consumption, staging API origin, prerender determinism (typewriter + provider gates), aria-live scoping, fetch timeout, comment hygiene. All resolved.
