### PR TITLE
fix: correct notification task links

### DIFF
--- a/backend/src/webwhen/notifications/novu_service.py
+++ b/backend/src/webwhen/notifications/novu_service.py
@@ -3,6 +3,7 @@
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from urllib.parse import quote
 
 from pydantic import BaseModel
 
@@ -60,7 +61,7 @@ def _format_sources(sources: list[dict], limit: int = 5) -> list[dict]:
 
 def _build_task_url(task_id: str) -> str:
     """Build the canonical frontend task detail URL for notification CTAs."""
-    return f"{settings.frontend_url.rstrip('/')}/tasks/{task_id}"
+    return f"{settings.frontend_url.rstrip('/')}/tasks/{quote(task_id, safe='')}"
 
 
 class NovuTriggerResult(BaseModel):

--- a/backend/src/webwhen/notifications/novu_service.py
+++ b/backend/src/webwhen/notifications/novu_service.py
@@ -58,6 +58,11 @@ def _format_sources(sources: list[dict], limit: int = 5) -> list[dict]:
     return [{"uri": s.get("url", ""), "title": s.get("title", "Unknown")} for s in sources[:limit]]
 
 
+def _build_task_url(task_id: str) -> str:
+    """Build the canonical frontend task detail URL for notification CTAs."""
+    return f"{settings.frontend_url.rstrip('/')}/tasks/{task_id}"
+
+
 class NovuTriggerResult(BaseModel):
     """Result from triggering a Novu workflow."""
 
@@ -149,6 +154,7 @@ class NovuService:
                 ),
                 "grounding_sources": _format_sources(payload.grounding_sources),
                 "task_id": payload.task_id,
+                "task_url": _build_task_url(payload.task_id),
                 "execution_id": execution_id,
                 "next_run": _format_next_run(payload.next_run),
                 "confidence": _format_confidence(confidence),
@@ -197,6 +203,7 @@ class NovuService:
                 ),
                 "grounding_sources": formatted_sources,
                 "task_id": payload.task_id,
+                "task_url": _build_task_url(payload.task_id),
                 "next_run": _format_next_run(payload.next_run),
             },
         )

--- a/backend/tests/test_novu_service.py
+++ b/backend/tests/test_novu_service.py
@@ -1,8 +1,16 @@
 """Tests for Novu notification helpers."""
 
+from unittest.mock import AsyncMock
+
 import pytest
 
-from webwhen.notifications.novu_service import _format_confidence
+from webwhen.core.config import settings
+from webwhen.notifications.novu_service import (
+    NotificationPayload,
+    NovuService,
+    _build_task_url,
+    _format_confidence,
+)
 
 
 class TestFormatConfidence:
@@ -24,3 +32,39 @@ class TestFormatConfidence:
     )
     def test_format(self, value, expected):
         assert _format_confidence(value) == expected
+
+
+class TestTaskUrl:
+    def test_builds_canonical_frontend_task_url(self, monkeypatch):
+        monkeypatch.setattr(settings, "frontend_url", "https://webwhen.ai/")
+
+        assert (
+            _build_task_url("76243542-8019-44d3-b171-4fb334d6f822")
+            == "https://webwhen.ai/tasks/76243542-8019-44d3-b171-4fb334d6f822"
+        )
+
+    @pytest.mark.asyncio
+    async def test_condition_met_payload_includes_task_url(self, monkeypatch):
+        monkeypatch.setattr(settings, "frontend_url", "https://webwhen.ai")
+        service = NovuService()
+        service._trigger = AsyncMock()
+
+        await service.send_condition_met_notification(
+            payload=NotificationPayload(
+                subscriber_id="user@example.com",
+                task_name="iPhone release",
+                search_query="iPhone release date",
+                answer="Apple announced the release date.",
+                grounding_sources=[],
+                task_id="76243542-8019-44d3-b171-4fb334d6f822",
+            ),
+            execution_id="exec-123",
+            confidence=95,
+        )
+
+        sent_payload = service._trigger.call_args.kwargs["payload"]
+        assert sent_payload["task_id"] == "76243542-8019-44d3-b171-4fb334d6f822"
+        assert (
+            sent_payload["task_url"]
+            == "https://webwhen.ai/tasks/76243542-8019-44d3-b171-4fb334d6f822"
+        )

--- a/backend/tests/test_novu_service.py
+++ b/backend/tests/test_novu_service.py
@@ -43,6 +43,11 @@ class TestTaskUrl:
             == "https://webwhen.ai/tasks/76243542-8019-44d3-b171-4fb334d6f822"
         )
 
+    def test_url_encodes_task_id(self, monkeypatch):
+        monkeypatch.setattr(settings, "frontend_url", "https://webwhen.ai")
+
+        assert _build_task_url("task/../id") == "https://webwhen.ai/tasks/task%2F..%2Fid"
+
     @pytest.mark.asyncio
     async def test_condition_met_payload_includes_task_url(self, monkeypatch):
         monkeypatch.setattr(settings, "frontend_url", "https://webwhen.ai")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -78,7 +78,8 @@
         "serve-handler": "^6.1.7",
         "tailwindcss": "^3.4.11",
         "typescript": "^5.5.3",
-        "vite": "^8.0.10"
+        "vite": "^8.0.10",
+        "vitest": "^4.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -3456,6 +3457,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -3527,6 +3539,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3846,6 +3865,119 @@
         "vite": "^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3980,6 +4112,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/autoprefixer": {
@@ -4178,6 +4320,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -4383,6 +4535,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/core-js": {
       "version": "3.49.0",
@@ -4758,6 +4917,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-toolkit": {
       "version": "1.46.1",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
@@ -5031,6 +5197,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5046,6 +5222,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -6190,6 +6376,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
@@ -6983,6 +7179,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7159,6 +7366,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8167,6 +8381,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -8216,6 +8437,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -8451,6 +8679,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -8466,6 +8711,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -8916,6 +9171,103 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/web-vitals": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
@@ -8936,6 +9288,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -85,6 +85,7 @@
     "serve-handler": "^6.1.7",
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
-    "vite": "^8.0.10"
+    "vite": "^8.0.10",
+    "vitest": "^4.1.6"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -315,7 +315,7 @@ function WatchRouteRedirect() {
     return <Navigate to="/" replace />
   }
 
-  return <Navigate to={`/tasks/${taskId}${location.search}`} replace />
+  return <Navigate to={`/tasks/${encodeURIComponent(taskId)}${location.search}`} replace />
 }
 
 function HomeRoute() {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -242,6 +242,10 @@ export default function App() {
           }
         />
         <Route
+          path="/watches/:taskId"
+          element={<WatchRouteRedirect />}
+        />
+        <Route
           path="/admin"
           element={
             <ProtectedRoute>
@@ -301,6 +305,17 @@ function TaskDetailRoute({ onBack, onDeleted }: { onBack: () => void; onDeleted:
       currentUserId={user?.id}
     />
   )
+}
+
+function WatchRouteRedirect() {
+  const { taskId } = useParams()
+  const location = useLocation()
+
+  if (!taskId) {
+    return <Navigate to="/" replace />
+  }
+
+  return <Navigate to={`/tasks/${taskId}${location.search}`} replace />
 }
 
 function HomeRoute() {

--- a/frontend/src/components/RootErrorBoundary.tsx
+++ b/frontend/src/components/RootErrorBoundary.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+interface RootErrorBoundaryState {
+  error: Error | null
+}
+
+export class RootErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  RootErrorBoundaryState
+> {
+  state: RootErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): RootErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error('Root render error:', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="min-h-screen flex items-center justify-center bg-background px-6 text-center">
+          <div>
+            <h1 className="text-xl font-medium text-foreground">Something went wrong.</h1>
+            <p className="mt-2 text-sm text-muted-foreground">Refresh the page to try again.</p>
+          </div>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -1,0 +1,54 @@
+import { renderToString } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { AuthProvider, hasActiveClerkSessionCookie, useAuth } from './AuthContext'
+
+function AuthProbe() {
+  const auth = useAuth()
+  return (
+    <div
+      data-auth-loaded={String(auth.isLoaded)}
+      data-authenticated={String(auth.isAuthenticated)}
+    />
+  )
+}
+
+describe('hasActiveClerkSessionCookie', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('treats missing Clerk state as anonymous', () => {
+    expect(hasActiveClerkSessionCookie('')).toBe(false)
+    expect(hasActiveClerkSessionCookie('theme=light')).toBe(false)
+    expect(hasActiveClerkSessionCookie('__client_uatbackup=1778560000')).toBe(false)
+  })
+
+  it('treats Clerk signed-out marker cookies as anonymous', () => {
+    expect(hasActiveClerkSessionCookie('__client_uat=0')).toBe(false)
+    expect(hasActiveClerkSessionCookie('__client_uat=0; __client_uat_UU_Qftd4=0')).toBe(false)
+  })
+
+  it('detects active Clerk timestamp cookies', () => {
+    expect(hasActiveClerkSessionCookie('__client_uat=1778560000')).toBe(true)
+    expect(hasActiveClerkSessionCookie('__client_uat = 1778560000')).toBe(true)
+    expect(hasActiveClerkSessionCookie('foo=bar; __client_uat_UU_Qftd4=1778560000')).toBe(true)
+  })
+
+  it('keeps the first marketing-route render anonymous with an active Clerk cookie', () => {
+    vi.stubGlobal('window', { __PRERENDER__: false, CONFIG: {} })
+    vi.stubGlobal('document', { cookie: '__client_uat=1778560000' })
+
+    const html = renderToString(
+      <MemoryRouter initialEntries={['/']}>
+        <AuthProvider>
+          <AuthProbe />
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+
+    expect(html).toContain('data-auth-loaded="false"')
+    expect(html).toContain('data-authenticated="false"')
+  })
+})

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -111,14 +111,22 @@ function isAuthRequiredPath(pathname: string): boolean {
 }
 
 // Clerk sets `__client_uat` (user authenticated timestamp) on the app domain.
-// It's JS-readable by design — Clerk uses it client-side to detect "is this
-// browser signed in" before paying the cost of loading the full SDK. We use
-// the same probe so logged-in users on / still get the "Dashboard" nav.
-// Note: `__session` is the JWT and is HttpOnly under Clerk's defaults, so it
-// can't be read from JS. Only `__client_uat` works as a cheap signal here.
+// It may also leave `__client_uat=0` behind as a signed-out state marker, so
+// presence alone is not enough to infer an active session.
+export function hasActiveClerkSessionCookie(cookieString: string): boolean {
+  const cookies = cookieString.split(';')
+  return cookies.some((cookie) => {
+    const [rawName, rawValue] = cookie.trim().split('=')
+    const name = rawName.trim()
+    if (!name || !/^__client_uat(?:_|$)/.test(name)) return false
+    const value = Number(rawValue)
+    return Number.isFinite(value) && value > 0
+  })
+}
+
 function hasClerkSession(): boolean {
   if (typeof document === 'undefined') return false
-  return /(?:^|;\s*)__client_uat=/.test(document.cookie)
+  return hasActiveClerkSessionCookie(document.cookie)
 }
 
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
@@ -128,6 +136,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   // order stays stable in practice — but reading the location up front keeps
   // the dependency obvious and lint-clean.
   const { pathname } = useLocation()
+  const authRequired = isAuthRequiredPath(pathname)
+  const [shouldHydrateMarketingClerk, setShouldHydrateMarketingClerk] = useState(false)
+
+  useEffect(() => {
+    setShouldHydrateMarketingClerk(hasClerkSession())
+  }, [pathname])
 
   // VITE_WEBWHEN_NOAUTH is the local-dev escape hatch — runs against a mocked
   // user end-to-end. NoAuthProvider returns a stable mock user so dev flows
@@ -146,12 +160,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     return <PendingAuthProvider>{children}</PendingAuthProvider>
   }
 
-  // Anonymous visitor on a marketing route: skip the Clerk lazy import so
-  // /, /changelog, /compare/*, /use-cases/*, /concepts/*, /terms, /privacy
-  // never trigger ~250 KiB of Clerk SDK + 2 auth XHRs during the LCP window.
-  // Logged-in users (cookie present) still get Clerk hydrated so Nav can
-  // swap "Sign in" → "Dashboard".
-  if (!isAuthRequiredPath(pathname) && !hasClerkSession()) {
+  // Marketing routes are prerendered with anonymous auth state. Keep the first
+  // client render identical, then hydrate Clerk after mount only when Clerk's
+  // active-session timestamp says there is a real signed-in browser session.
+  if (!authRequired && !shouldHydrateMarketingClerk) {
     return <MarketingAuthProvider>{children}</MarketingAuthProvider>
   }
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -121,6 +121,6 @@ export function formatTimeAgo(dateString: string): string {
   if (diffMins < 1) return 'Just now';
   if (diffMins < MINS_IN_HOUR) return `${diffMins}m ago`;
   if (diffMins < MINS_IN_DAY) return `${Math.floor(diffMins / MINS_IN_HOUR)}h ago`;
-  if (diffMins < MINS_IN_WEEK) return `${Math.floor(diffMins / MINS_IN_DAY)}d ago`;
+  if (diffMins <= MINS_IN_WEEK) return `${Math.floor(diffMins / MINS_IN_DAY)}d ago`;
   return date.toLocaleDateString();
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import { AuthProvider } from './contexts/AuthContext'
+import { RootErrorBoundary } from './components/RootErrorBoundary'
 import App from './App'
 import './index.css'
 
@@ -11,13 +12,15 @@ import './index.css'
 // without a Clerk session cookie skip the lazy import entirely.
 const app = (
   <React.StrictMode>
-    <HelmetProvider>
-      <BrowserRouter>
-        <AuthProvider>
-          <App />
-        </AuthProvider>
-      </BrowserRouter>
-    </HelmetProvider>
+    <RootErrorBoundary>
+      <HelmetProvider>
+        <BrowserRouter>
+          <AuthProvider>
+            <App />
+          </AuthProvider>
+        </BrowserRouter>
+      </HelmetProvider>
+    </RootErrorBoundary>
   </React.StrictMode>
 )
 


### PR DESCRIPTION
## Summary
- add canonical `task_url` to Novu notification payloads using `/tasks/{task_id}`
- keep `task_id` for existing templates while giving Novu CTAs a repo-generated URL
- add `/watches/:taskId` frontend redirect to recover already-sent notification links

## Novu template note
The bad CTA likely comes from the external `torale-condition-met` template composing `https://webwhen.ai/watches/{{task_id}}`. Update the CTA URL to `{{task_url}}`. If `torale-task-welcome` has a task CTA, update it the same way.

## Verification
- `cd backend && uv run --all-extras pytest tests/test_novu_service.py -v`
- `cd backend && uv run ruff check . && uv run ruff format --check .`
- `cd frontend && npm run lint && npx tsc --noEmit`

Frontend lint/tsc passed with one existing warning in `frontend/src/components/dashboard/WatchList.tsx` for an unused `Search` import; untouched.