### PR TITLE
fix: initialize authed api client in app routes

### DIFF
--- a/frontend/app/(app)/AuthedApiBootstrap.tsx
+++ b/frontend/app/(app)/AuthedApiBootstrap.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import type { ReactNode } from 'react'
+
+import { useApiSetup } from '@/hooks/useApi'
+
+export function AuthedApiBootstrap({ children }: { children: ReactNode }) {
+  useApiSetup()
+
+  return <>{children}</>
+}

--- a/frontend/app/(app)/layout.tsx
+++ b/frontend/app/(app)/layout.tsx
@@ -7,6 +7,7 @@ export const dynamic = 'force-dynamic'
 
 import { AuthProvider } from '@/contexts/AuthContext'
 import { NoAuthProvider } from '@/contexts/NoAuthProvider'
+import { AuthedApiBootstrap } from './AuthedApiBootstrap'
 
 // The (app) route group is the only place (alongside (auth)) where Clerk
 // mounts. Marketing routes live outside this subtree and never load Clerk JS,
@@ -16,11 +17,17 @@ import { NoAuthProvider } from '@/contexts/NoAuthProvider'
 // entirely and render a stable mock user via NoAuthProvider.
 export default function AppLayout({ children }: { children: ReactNode }) {
   if (process.env.NEXT_PUBLIC_WEBWHEN_NOAUTH === '1') {
-    return <NoAuthProvider>{children}</NoAuthProvider>
+    return (
+      <NoAuthProvider>
+        <AuthedApiBootstrap>{children}</AuthedApiBootstrap>
+      </NoAuthProvider>
+    )
   }
   return (
     <ClerkProvider waitlistUrl="/waitlist">
-      <AuthProvider>{children}</AuthProvider>
+      <AuthProvider>
+        <AuthedApiBootstrap>{children}</AuthedApiBootstrap>
+      </AuthProvider>
     </ClerkProvider>
   )
 }


### PR DESCRIPTION
## Summary
- Add a tiny client bootstrap under the authenticated app route group that calls useApiSetup()
- Wrap (app) children inside the existing AuthProvider/NoAuthProvider boundary so API calls get Clerk tokens without making the layout a client component

## Validation
- npm run typecheck
- npm run build
- Public smoke: https://webwhen.ai/ loads and reports title "webwhen — the agent that waits for the web · webwhen"
- Auth smoke attempted with agent-browser --profile ~/.agent-browser/me-prass-profile, but the profile is not currently authenticated and is blocked at accounts.webwhen.ai Cloudflare/sign-in before reaching /dashboard or /admin