### PR TITLE
fix: keep production watches active and repair notification links

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -4,3 +4,5 @@
 - [project_infra_gotchas.md](project_infra_gotchas.md) - GKE Autopilot spot preemptions, cloud-sql-proxy auth delays, agent cold-start probe failures
 - [project_gemini_503s.md](project_gemini_503s.md) - Gemini 503s classified as "unknown" not "rate_limit" in errors.py; 19% failure rate, open issue
 - [project_execution_id_reuse_legacy.md](project_execution_id_reuse_legacy.md) - Pre-PR#207 rows have inflated durations and stale errors; don't backfill, they age out
+- [project_notification_links.md](project_notification_links.md) - Notification CTAs are owner links; public `/tasks/:id` returns 404 for private watches
+- [project_watch_lifecycle.md](project_watch_lifecycle.md) - Watches are user-controlled; suppress agent auto-completion and guard rescheduling races

--- a/.claude/memory/project_notification_links.md
+++ b/.claude/memory/project_notification_links.md
@@ -1,0 +1,15 @@
+---
+name: notification-owner-links
+description: Notification CTAs must use the authenticated owner route, not the public watch route
+type: project
+---
+
+Notification emails are sent to a watch owner and must link to
+`/dashboard/tasks/:id`. The `/tasks/:id` route is an anonymous, statically
+rendered public page and intentionally returns 404 when `tasks.is_public` is
+false.
+
+Legacy notification links used `/watches/:id`. Keep that redirect pointed at
+`/dashboard/tasks/:id` so old emails remain usable. The backend-generated
+`task_url` and any explicit links in the live Novu templates must also resolve
+to that authenticated owner route.

--- a/.claude/memory/project_watch_lifecycle.md
+++ b/.claude/memory/project_watch_lifecycle.md
@@ -1,0 +1,6 @@
+# Watch lifecycle safety
+
+- Watches are ongoing by default. Only an explicit user/admin state transition may pause or complete one.
+- Agent output `next_run=null` is not trusted as a task-state command. The backend records `agent_requested_completion` / `completion_suppressed` in the execution result and schedules a 24-hour fallback.
+- `_schedule_next_run()` claims the schedule only while `tasks.state = 'active'` and re-checks after adding the APScheduler job. This prevents an in-flight run from resurrecting a concurrently paused/completed watch.
+- Production audit on 2026-08-08 found 11 incorrectly auto-completed recurring watches and 13 stale nonterminal execution rows from early 2026.

--- a/backend/src/webwhen/notifications/novu_service.py
+++ b/backend/src/webwhen/notifications/novu_service.py
@@ -60,8 +60,8 @@ def _format_sources(sources: list[dict], limit: int = 5) -> list[dict]:
 
 
 def _build_task_url(task_id: str) -> str:
-    """Build the canonical frontend task detail URL for notification CTAs."""
-    return f"{settings.frontend_url.rstrip('/')}/tasks/{quote(task_id, safe='')}"
+    """Build the authenticated owner-view URL for notification CTAs."""
+    return f"{settings.frontend_url.rstrip('/')}/dashboard/tasks/{quote(task_id, safe='')}"
 
 
 class NovuTriggerResult(BaseModel):

--- a/backend/src/webwhen/scheduler/job.py
+++ b/backend/src/webwhen/scheduler/job.py
@@ -11,6 +11,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
 
+from apscheduler.jobstores.base import JobLookupError
 from apscheduler.triggers.date import DateTrigger
 
 from webwhen.core.database import db
@@ -45,7 +46,6 @@ from webwhen.scheduler.models import (
 from webwhen.scheduler.prompt_sanitizer import PromptSanitizer
 from webwhen.scheduler.scheduler import get_scheduler
 from webwhen.tasks import TaskState, TaskStatus
-from webwhen.tasks.service import TaskService
 
 logger = logging.getLogger(__name__)
 
@@ -84,10 +84,33 @@ async def _schedule_next_run(
     execution_id: str | None,
     retry_count: int = 0,
 ) -> None:
-    """Schedule an APScheduler job and persist next_run to DB."""
+    """Persist and schedule the next run while the task remains active.
+
+    A user can pause or complete a task while its current execution is still
+    running. Claim the schedule with an active-state UPDATE, then re-check the
+    state after adding the job so that an in-flight execution cannot resurrect
+    a task that changed state concurrently.
+    """
     try:
-        scheduler = get_scheduler()
         job_id = f"task-{task_id}"
+        task_uuid = uuid.UUID(task_id)
+        claimed = await db.fetch_one(
+            """UPDATE tasks
+               SET next_run = $1
+               WHERE id = $2 AND state = $3
+               RETURNING id""",
+            next_run_dt,
+            task_uuid,
+            TaskState.ACTIVE.value,
+        )
+        if not claimed:
+            logger.info(
+                "Skipped scheduling task %s because it is no longer active",
+                task_id,
+            )
+            return
+
+        scheduler = get_scheduler()
         scheduler.add_job(
             JOB_FUNC_REF,
             trigger=DateTrigger(run_date=next_run_dt),
@@ -95,11 +118,19 @@ async def _schedule_next_run(
             args=[task_id, user_id, task_name, retry_count, execution_id],
             replace_existing=True,
         )
-        await db.execute(
-            "UPDATE tasks SET next_run = $1 WHERE id = $2",
-            next_run_dt,
-            uuid.UUID(task_id),
-        )
+
+        current = await db.fetch_one("SELECT state FROM tasks WHERE id = $1", task_uuid)
+        if not current or current["state"] != TaskState.ACTIVE.value:
+            try:
+                scheduler.remove_job(job_id)
+            except JobLookupError:
+                pass
+            logger.info(
+                "Removed newly scheduled job for task %s after a concurrent state change",
+                task_id,
+            )
+            return
+
         logger.info(f"Scheduled task {task_id} next run at {next_run_dt.isoformat()}")
     except Exception as e:
         logger.error(f"Failed to schedule next run for task {task_id}: {e}", exc_info=True)
@@ -413,23 +444,25 @@ async def _execute(
         # For permanent failures, the task is marked FAILED and no further retries are scheduled.
         # The task will not be automatically rescheduled - user needs to fix the issue and manually re-activate if desired.
     finally:
-        if execution_succeeded and next_run_value is None:
-            # Agent returned next_run=null → monitoring complete
-            try:
-                task_service = TaskService(db=db)
-                await task_service.complete(
-                    task_id=uuid.UUID(task_id), current_state=TaskState.ACTIVE
+        if execution_succeeded:
+            # A watch is ongoing unless a person explicitly changes its state.
+            # LLM-generated next_run=null has incorrectly completed recurring
+            # watches in production, including runs that found no change at all.
+            # Preserve the request in the execution audit trail and fall back to
+            # 24 hours rather than trusting it as a state transition command.
+            if next_run_value is None:
+                await _merge_execution_result(
+                    execution_id,
+                    {
+                        "agent_requested_completion": True,
+                        "completion_suppressed": True,
+                    },
                 )
-                await db.execute(
-                    "UPDATE tasks SET next_run = NULL WHERE id = $1",
-                    uuid.UUID(task_id),
+                logger.warning(
+                    "Suppressed automatic completion for task %s; scheduling fallback run",
+                    task_id,
                 )
-                logger.info(f"Task {task_id} completed (agent returned next_run=null)")
-            except Exception as e:
-                logger.error(f"Auto-complete failed for task {task_id}: {e}", exc_info=True)
-                await _merge_execution_result(execution_id, {"auto_complete_failed": True})
-        elif execution_succeeded:
-            # Agent returned a next_run date → schedule next check.
+
             # Pass execution_id=None so the next scheduled run creates its own
             # row. Reusing the current execution_id would cause subsequent runs
             # to overwrite this row's completed_at, producing inflated durations

--- a/backend/src/webwhen/scheduler/models.py
+++ b/backend/src/webwhen/scheduler/models.py
@@ -83,7 +83,10 @@ class MonitoringResponse(BaseModel):
     confidence: int = Field(ge=0, le=100, description="Confidence level 0-100")
     next_run: str | None = Field(
         default=None,
-        description="ISO timestamp for next check, or null if monitoring is complete",
+        description=(
+            "ISO timestamp for the next check. Null is accepted for protocol compatibility "
+            "but is converted to a fallback run."
+        ),
     )
     notification: str | None = Field(
         default=None,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -124,7 +124,6 @@ def job_mocks():
         patch(f"{JOB_MODULE}.send_email_notification", new_callable=AsyncMock) as mock_email,
         patch(f"{JOB_MODULE}.send_webhook_notification", new_callable=AsyncMock) as mock_webhook,
         patch(f"{JOB_MODULE}.get_scheduler") as mock_scheduler,
-        patch(f"{JOB_MODULE}.TaskService") as mock_service_cls,
         patch(f"{JOB_MODULE}.fetch_recent_executions", new_callable=AsyncMock) as mock_recent_execs,
     ):
         mock_db.execute = AsyncMock()
@@ -140,7 +139,6 @@ def job_mocks():
         mocks.email = mock_email
         mocks.webhook = mock_webhook
         mocks.scheduler = mock_scheduler
-        mocks.service_cls = mock_service_cls
         mocks.recent_execs = mock_recent_execs
 
         yield mocks

--- a/backend/tests/test_job.py
+++ b/backend/tests/test_job.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 import pytest
 
 from webwhen.scheduler.history import ExecutionRecord
-from webwhen.scheduler.job import _execute, execute_task_job
+from webwhen.scheduler.job import _execute, _schedule_next_run, execute_task_job
 from webwhen.scheduler.models import MonitoringResponse, NotificationContext
 
 TASK_ID = str(uuid4())
@@ -70,8 +70,8 @@ class TestExecute:
         job_mocks.webhook.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_next_run_none_completes_task(self, job_mocks):
-        """Agent returns next_run=null -> task completed after notification."""
+    async def test_next_run_none_schedules_fallback(self, job_mocks):
+        """Agent next_run=null is audited and converted to a fallback run."""
         job_mocks.db.fetch_one = AsyncMock(return_value=_make_task_row())
         job_mocks.agent.return_value = _make_agent_response(
             notification="Release date is Sept 9", next_run=None
@@ -79,14 +79,17 @@ class TestExecute:
         job_mocks.fetch_ctx.return_value = _make_notification_context()
         job_mocks.email.return_value = True
 
-        mock_service = MagicMock()
-        mock_service.complete = AsyncMock()
-        job_mocks.service_cls.return_value = mock_service
+        mock_sched = MagicMock()
+        job_mocks.scheduler.return_value = mock_sched
 
         await _execute(TASK_ID, EXECUTION_ID, USER_ID, TASK_NAME)
 
         job_mocks.email.assert_awaited_once()
-        mock_service.complete.assert_awaited_once()
+        mock_sched.add_job.assert_called_once()
+        merge_calls = [
+            call for call in job_mocks.db.execute.call_args_list if "result =" in call.args[0]
+        ]
+        assert any("completion_suppressed" in str(call) for call in merge_calls)
 
     @pytest.mark.asyncio
     async def test_next_run_set_does_not_complete(self, job_mocks):
@@ -99,7 +102,7 @@ class TestExecute:
         await _execute(TASK_ID, EXECUTION_ID, USER_ID, TASK_NAME)
 
         job_mocks.email.assert_awaited_once()
-        job_mocks.service_cls.assert_not_called()
+        job_mocks.scheduler.return_value.add_job.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_notification_failure_still_reschedules(self, job_mocks):
@@ -114,12 +117,11 @@ class TestExecute:
 
         await _execute(TASK_ID, EXECUTION_ID, USER_ID, TASK_NAME)
 
-        job_mocks.service_cls.assert_not_called()
         mock_sched.add_job.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_next_run_none_completes_even_if_notification_fails(self, job_mocks):
-        """next_run=null + notification failure -> task still completes."""
+    async def test_next_run_none_reschedules_even_if_notification_fails(self, job_mocks):
+        """A notification failure does not turn next_run=null into completion."""
         job_mocks.db.fetch_one = AsyncMock(return_value=_make_task_row())
         job_mocks.agent.return_value = _make_agent_response(
             notification="Condition met", next_run=None
@@ -127,13 +129,60 @@ class TestExecute:
         job_mocks.fetch_ctx.return_value = _make_notification_context()
         job_mocks.email.side_effect = RuntimeError("SMTP error")
 
-        mock_service = MagicMock()
-        mock_service.complete = AsyncMock()
-        job_mocks.service_cls.return_value = mock_service
+        mock_sched = MagicMock()
+        job_mocks.scheduler.return_value = mock_sched
 
         await _execute(TASK_ID, EXECUTION_ID, USER_ID, TASK_NAME)
 
-        mock_service.complete.assert_awaited_once()
+        mock_sched.add_job.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_next_run_none_without_notification_still_reschedules(self, job_mocks):
+        """No-change runs can never silently stop a watch."""
+        job_mocks.db.fetch_one = AsyncMock(return_value=_make_task_row())
+        job_mocks.agent.return_value = _make_agent_response(notification=None, next_run=None)
+        mock_sched = MagicMock()
+        job_mocks.scheduler.return_value = mock_sched
+
+        await _execute(TASK_ID, EXECUTION_ID, USER_ID, TASK_NAME)
+
+        job_mocks.email.assert_not_awaited()
+        mock_sched.add_job.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reschedule_skips_task_that_is_no_longer_active(self, job_mocks):
+        """An in-flight run cannot schedule after a concurrent pause/archive."""
+        job_mocks.db.fetch_one = AsyncMock(return_value=None)
+        mock_sched = MagicMock()
+        job_mocks.scheduler.return_value = mock_sched
+
+        await _schedule_next_run(
+            TASK_ID,
+            USER_ID,
+            TASK_NAME,
+            datetime.now(UTC) + timedelta(hours=1),
+            execution_id=None,
+        )
+
+        mock_sched.add_job.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reschedule_removes_job_after_concurrent_state_change(self, job_mocks):
+        """A state change between the DB claim and add_job wins the race."""
+        job_mocks.db.fetch_one = AsyncMock(side_effect=[{"id": TASK_ID}, {"state": "paused"}])
+        mock_sched = MagicMock()
+        job_mocks.scheduler.return_value = mock_sched
+
+        await _schedule_next_run(
+            TASK_ID,
+            USER_ID,
+            TASK_NAME,
+            datetime.now(UTC) + timedelta(hours=1),
+            execution_id=None,
+        )
+
+        mock_sched.add_job.assert_called_once()
+        mock_sched.remove_job.assert_called_once_with(f"task-{TASK_ID}")
 
     @pytest.mark.asyncio
     async def test_agent_failure_marks_failed(self, job_mocks):

--- a/backend/tests/test_novu_service.py
+++ b/backend/tests/test_novu_service.py
@@ -40,13 +40,13 @@ class TestTaskUrl:
 
         assert (
             _build_task_url("76243542-8019-44d3-b171-4fb334d6f822")
-            == "https://webwhen.ai/tasks/76243542-8019-44d3-b171-4fb334d6f822"
+            == "https://webwhen.ai/dashboard/tasks/76243542-8019-44d3-b171-4fb334d6f822"
         )
 
     def test_url_encodes_task_id(self, monkeypatch):
         monkeypatch.setattr(settings, "frontend_url", "https://webwhen.ai")
 
-        assert _build_task_url("task/../id") == "https://webwhen.ai/tasks/task%2F..%2Fid"
+        assert _build_task_url("task/../id") == "https://webwhen.ai/dashboard/tasks/task%2F..%2Fid"
 
     @pytest.mark.asyncio
     async def test_condition_met_payload_includes_task_url(self, monkeypatch):
@@ -71,5 +71,5 @@ class TestTaskUrl:
         assert sent_payload["task_id"] == "76243542-8019-44d3-b171-4fb334d6f822"
         assert (
             sent_payload["task_url"]
-            == "https://webwhen.ai/tasks/76243542-8019-44d3-b171-4fb334d6f822"
+            == "https://webwhen.ai/dashboard/tasks/76243542-8019-44d3-b171-4fb334d6f822"
         )

--- a/backend/tests/test_retry_execution_id.py
+++ b/backend/tests/test_retry_execution_id.py
@@ -24,6 +24,7 @@ async def test_schedule_next_run_passes_execution_id():
         mock_scheduler = MagicMock()
         mock_get_scheduler.return_value = mock_scheduler
         mock_db.execute = AsyncMock()
+        mock_db.fetch_one = AsyncMock(side_effect=[{"id": TASK_ID}, {"state": "active"}])
 
         next_run_dt = datetime.now(UTC)
         retry_count = 2

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -79,13 +79,17 @@ const nextConfig = {
     //   ^/(?!index\.html$|404\.html$)(.+)\.html$ /$1 — general .html strip.
     //
     // Plus app-level redirects from src/App.tsx:
-    //   /watches/:taskId → /tasks/:taskId (legacy URL shape).
+    //   /watches/:taskId → /dashboard/tasks/:taskId (legacy owner URL shape).
     //   /settings → /settings/notifications (bare /settings has no UI).
     return [
       { source: '/index.html', destination: '/', permanent: true },
       { source: '/index', destination: '/', permanent: true },
       { source: '/:path*.html', destination: '/:path*', permanent: true },
-      { source: '/watches/:taskId', destination: '/tasks/:taskId', permanent: true },
+      {
+        source: '/watches/:taskId',
+        destination: '/dashboard/tasks/:taskId',
+        permanent: true,
+      },
       { source: '/settings', destination: '/settings/notifications', permanent: true },
       // Retired sitemap children (collapsed into the unified /sitemap.xml).
       // Googlebot and other crawlers may have the old sitemap-index entries

--- a/torale-agent/models.py
+++ b/torale-agent/models.py
@@ -55,7 +55,10 @@ class MonitoringResponse(BaseModel):
     confidence: int = Field(ge=0, le=100, description="Confidence level 0-100")
     next_run: str | None = Field(
         default=None,
-        description="ISO timestamp for next check, or null if monitoring is complete",
+        description=(
+            "ISO timestamp for the next check. Null is accepted for protocol compatibility "
+            "but the backend converts it to a fallback run."
+        ),
     )
     notification: str | None = Field(
         default=None,

--- a/torale-agent/prompts.py
+++ b/torale-agent/prompts.py
@@ -101,7 +101,7 @@ document. Two short paragraphs is the maximum.
 7. **Determine next run** — When should this be checked again?
    - **ALWAYS set `next_run` to an ISO timestamp.** The user created this monitor to keep watching — your job is to keep checking.
    - "Nothing changed" or "no new information" means schedule the next check, NOT stop monitoring. The user wants ongoing surveillance.
-   - Set `next_run` to `null` ONLY when the monitoring goal is permanently and irreversibly achieved (e.g., "the release date was officially announced and the user was notified"). This is extremely rare — most monitors should run indefinitely.
+   - **Never set `next_run` to `null`.** Watch state changes are controlled by the user, not by an agent run. Even after a condition is met, schedule a later check; execution history prevents duplicate notifications.
    - If this is the first check (no execution history), set `next_run` to within 24 hours — early runs build context faster
    - Scale frequency to the topic: fast-moving or time-sensitive topics (breaking news, imminent launches) → check in hours; slow-moving topics (events months away) → check in days
    - Avoid scheduling on round hours (e.g., 10:00, 14:00) — pick a random minute offset to spread API load across monitors
@@ -140,7 +140,7 @@ Return ONLY valid JSON matching this schema:
   "evidence": "Internal reasoning and what was found (audit trail, not user-facing)",
   "sources": ["url1", "url2"],
   "confidence": 0–100,
-  "next_run": "ISO timestamp or null if done",
+  "next_run": "ISO timestamp for the next check",
   "notification": "(include ONLY if notification-worthy) 1-3 sentences of plain prose. NO markdown, NO headers, NO bullets, NO bold. See 'Notification voice' section above.",
   "topic": "Short lowercase title for the watch (optional, null if not needed)"
 }"""

--- a/torale-agent/tools.py
+++ b/torale-agent/tools.py
@@ -22,7 +22,7 @@ def _get_clients(ctx: RunContext[MonitoringDeps]) -> Clients | None:
 
 PARALLEL_SEARCH_MAX_RESULTS = 10
 PARALLEL_SEARCH_MAX_CHARS = 5000
-PARALLEL_SEARCH_BETAS = ("search-extract-2025-10-10",)
+PARALLEL_SEARCH_BETAS = ["search-extract-2025-10-10"]
 PARALLEL_SEARCH_MAX_EXCERPTS = 2
 
 FETCH_MAX_CHARS = 5000


### PR DESCRIPTION
## What changed

- routes notification CTAs and legacy `/watches/:id` links to the authenticated owner view
- treats watches as ongoing unless a user/admin explicitly changes their state
- converts agent `next_run=null` responses into audited 24-hour fallback runs
- prevents an in-flight execution from recreating a scheduler job after a concurrent pause/archive
- updates the agent prompt and duplicated response schema documentation
- fixes the Parallel SDK beta argument type caught by agent typechecking

## Root cause

The agent output schema allowed `next_run=null`, and the backend treated that probabilistic field as an authoritative state-transition command. This completed recurring watches even when a run found no change. Scheduling also had a race where a finishing execution could recreate a job after the watch changed state.

Notification emails additionally linked private watches through the public `/tasks/:id` route, which correctly returned 404.

## Impact

Watches now remain active after every successful agent run. Manual pause/archive behavior is unchanged. Completion requests are recorded in the execution result as `agent_requested_completion` and `completion_suppressed` for auditability.

## Validation

- `just lint`
- backend: 237 passed, 30 skipped
- agent: `ruff check`, `ty check`, server import smoke
- regression coverage for null responses with and without notifications, notification failure, and both concurrent state-change windows