### PR TITLE
feat: refresh agent model evaluation

### DIFF
--- a/torale-agent/README.md
+++ b/torale-agent/README.md
@@ -1,6 +1,6 @@
-# Torale Agent
+# webwhen Agent
 
-Monitoring agent service for the Torale platform. Uses Pydantic AI with Gemini for analyzing search results and determining if monitoring conditions are met.
+Watch agent service for webwhen. Uses Pydantic AI with Gemini to gather evidence and determine whether a watch condition has been met.
 
 ## Development
 
@@ -44,37 +44,23 @@ uv sync --group eval
 # List test cases
 uv run torale-agent eval list
 
-# Run evaluations with different models
-uv run torale-agent eval run --model google:gemini-3-flash-preview
-uv run torale-agent eval run --model google:gemini-2-0-flash-exp
-uv run torale-agent eval run --model claude-3-5-sonnet-20241022
-uv run torale-agent eval run --model gpt-4-turbo
+# Run the full suite with a candidate model
+uv run torale-agent eval run --model google:gemini-3.5-flash-lite
 
-# Run specific case
-uv run torale-agent eval run --case "GTA VI Release Date" --model claude-3-5-sonnet-20241022
+# Run the ground-truth trigger-decision subset
+uv run torale-agent eval run --decision-only --model google:gemini-3.5-flash-lite
+
+# Run a specific case
+uv run torale-agent eval run --case "Python 3.13 Released" --model google:gemini-3.5-flash-lite
 
 # Run only first N cases (useful for quick testing)
 uv run torale-agent eval run --limit 2
 
-# View recent results
-uv run torale-agent eval results
-
-# Compare models
-uv run torale-agent eval compare gemini-3-flash claude-3-5-sonnet
 ```
 
-**Model IDs:**
-- Google Gemini: `google:gemini-3-flash-preview`, `google:gemini-2-0-flash-exp`, `google:gemini-2-5-pro`, `google:gemini-2-5-flash`
-  - Note: Thinking config is automatically enabled for gemini-3-* and gemini-2.5-pro models only
-- Anthropic Claude: `claude-3-5-sonnet-20241022`, `claude-opus-4-1`
-- OpenAI: `gpt-4-turbo`, `gpt-4o`
+Requires `GEMINI_API_KEY`. Other providers require their corresponding API key.
 
-**Note:** Requires corresponding API keys as environment variables:
-- `GEMINI_API_KEY` for Google models
-- `ANTHROPIC_API_KEY` for Claude models
-- `OPENAI_API_KEY` for OpenAI models
-
-Test cases are stored in `evals/cases.jsonl` and derived from production task templates.
+Static cases are stored in `evals/cases.yaml`. `uv run torale-agent eval generate` creates a live-data dataset that can be included with `--with-dynamic`.
 
 ## Architecture
 

--- a/torale-agent/agent.py
+++ b/torale-agent/agent.py
@@ -1,4 +1,4 @@
-"""Torale monitoring agent factory."""
+"""webwhen watch agent factory."""
 
 from pydantic_ai import Agent
 from pydantic_ai.models.google import GoogleModelSettings

--- a/torale-agent/cli.py
+++ b/torale-agent/cli.py
@@ -84,13 +84,27 @@ def run(
     with_dynamic: bool = typer.Option(
         False, "--with-dynamic", help="Include latest dynamic cases"
     ),
+    decision_only: bool = typer.Option(
+        False,
+        "--decision-only",
+        help="Run only cases with an expected notification decision",
+    ),
     dataset: Path | None = typer.Option(
         None, help="Path to a specific dataset YAML file"
     ),
 ):
     """Run evaluation suite with specified model."""
     asyncio.run(
-        _run_async(model, case, limit, passes, max_concurrency, with_dynamic, dataset)
+        _run_async(
+            model,
+            case,
+            limit,
+            passes,
+            max_concurrency,
+            with_dynamic,
+            decision_only,
+            dataset,
+        )
     )
 
 
@@ -101,6 +115,7 @@ async def _run_async(
     passes: int,
     max_concurrency: int,
     with_dynamic: bool,
+    decision_only: bool,
     dataset_path: Path | None,
 ):
     from evals.models import MonitoringDataset
@@ -117,6 +132,12 @@ async def _run_async(
 
     # Filter and slice cases in one pass
     cases = list(ds.cases)
+    if decision_only:
+        cases = [
+            c
+            for c in cases
+            if c.metadata is not None and c.metadata.expected_notification is not None
+        ]
     if case_name:
         cases = [c for c in cases if c.name == case_name]
         if not cases:

--- a/torale-agent/evals/cases.yaml
+++ b/torale-agent/evals/cases.yaml
@@ -53,6 +53,60 @@ cases:
       condition_description: "A transfer is officially confirmed by clubs or reliable sources"
       category: Sports
 
+  # Durable decision-regression cases. These carry reviewed trigger/no-trigger
+  # ground truth and are the minimum meaningful set for model comparisons.
+  - name: Python 3.13 Released
+    inputs:
+      search_query: "Has Python 3.13 been officially released?"
+      condition_description: "Python 3.13 has an official final release from the Python Software Foundation"
+      category: Tech
+    metadata:
+      category: Tech
+      expected_notification: true
+      ground_truth: "Python 3.13 final was officially released on October 7, 2024."
+      ground_truth_as_of: "2026-08-08"
+    evaluators:
+      - NotificationDecision: {}
+
+  - name: Python 99 Not Released
+    inputs:
+      search_query: "Has Python 99 been officially released?"
+      condition_description: "Python 99 has an official final release from the Python Software Foundation"
+      category: Tech
+    metadata:
+      category: Tech
+      expected_notification: false
+      ground_truth: "No Python 99 release exists."
+      ground_truth_as_of: "2026-08-08"
+    evaluators:
+      - NotificationDecision: {}
+
+  - name: UK India FTA In Force
+    inputs:
+      search_query: "Has the UK-India Free Trade Agreement entered into force?"
+      condition_description: "The UK-India Free Trade Agreement is officially in force"
+      category: Policy
+    metadata:
+      category: Policy
+      expected_notification: true
+      ground_truth: "The agreement entered into force on July 15, 2026, per the UK government."
+      ground_truth_as_of: "2026-08-08"
+    evaluators:
+      - NotificationDecision: {}
+
+  - name: Impossible Mortgage Rate
+    inputs:
+      search_query: "What is the current average 30-year fixed mortgage rate in the US?"
+      condition_description: "The average 30-year fixed mortgage rate is below 0.1%"
+      category: Finance
+    metadata:
+      category: Finance
+      expected_notification: false
+      ground_truth: "The US average 30-year fixed mortgage rate is not below 0.1%."
+      ground_truth_as_of: "2026-08-08"
+    evaluators:
+      - NotificationDecision: {}
+
 evaluators:
   - SourcesWhenNotifying: {}
   - ReasonableNextRun: {}

--- a/torale-agent/evals/dynamic.py
+++ b/torale-agent/evals/dynamic.py
@@ -12,6 +12,7 @@ from pydantic_evals import Case, Dataset
 from evals.evaluators import (
     CUSTOM_EVALUATORS,
     FetchUrlUsed,
+    NotificationDecision,
     ReasonableNextRun,
     SearchToolUsed,
     SourcesWhenNotifying,
@@ -112,20 +113,36 @@ async def generate_stock_cases(client: httpx.AsyncClient) -> list[MonitoringCase
                     condition_description=f"{ticker} stock price rises above ${price + 10:.2f}",
                     category="Finance",
                 ),
-                metadata=_meta("Finance"),
+                metadata=MonitoringCaseMetadata(
+                    category="Finance",
+                    source="dynamic",
+                    generated_at=datetime.now(UTC).isoformat(),
+                    expected_notification=False,
+                    ground_truth=f"{ticker} was ${price:.2f} when this case was generated.",
+                    ground_truth_as_of=datetime.now(UTC).date().isoformat(),
+                ),
+                evaluators=(NotificationDecision(),),
             )
         )
 
-        # Case 2: threshold below current price (should notify)
+        # Case 2: current price is already above a lower threshold (should notify)
         cases.append(
             Case(
-                name=f"{ticker} Below {price - 10:.0f} (true)",
+                name=f"{ticker} Above {price - 10:.0f} (true)",
                 inputs=MonitoringCaseInput(
                     search_query=f"What is the current stock price of {company} ({ticker})?",
-                    condition_description=f"{ticker} stock price drops below ${price - 10:.2f}",
+                    condition_description=f"{ticker} stock price rises above ${price - 10:.2f}",
                     category="Finance",
                 ),
-                metadata=_meta("Finance"),
+                metadata=MonitoringCaseMetadata(
+                    category="Finance",
+                    source="dynamic",
+                    generated_at=datetime.now(UTC).isoformat(),
+                    expected_notification=True,
+                    ground_truth=f"{ticker} was ${price:.2f} when this case was generated.",
+                    ground_truth_as_of=datetime.now(UTC).date().isoformat(),
+                ),
+                evaluators=(NotificationDecision(),),
             )
         )
 
@@ -229,6 +246,7 @@ async def generate_webpage_cases(client: httpx.AsyncClient) -> list[MonitoringCa
                 category=page["category"],
             ),
             metadata=_meta(page["category"]),
+            evaluators=(FetchUrlUsed(),),
         )
         for page in pages
     ]
@@ -274,7 +292,6 @@ async def generate_and_save(output_dir: Path) -> Path:
             SourcesWhenNotifying(),
             ReasonableNextRun(),
             SearchToolUsed(),
-            FetchUrlUsed(),
         ],
     )
 

--- a/torale-agent/evals/evaluators.py
+++ b/torale-agent/evals/evaluators.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
-from pydantic_evals.evaluators import Evaluator, EvaluatorContext
+from pydantic_evals.evaluators import EvaluationReason, Evaluator, EvaluatorContext
 from pydantic_evals.otel._errors import SpanTreeRecordingError
 
 from evals.models import MonitoringCaseInput, MonitoringCaseMetadata
@@ -21,6 +21,11 @@ def _get_span_tree(ctx: EvalCtx):
         return ctx.span_tree
     except SpanTreeRecordingError:
         return None
+
+
+def _activity_tool_names(ctx: EvalCtx) -> list[str]:
+    """Return production-shaped tool activity recorded on the response."""
+    return [step.tool for step in (ctx.output.activity or [])]
 
 
 @dataclass
@@ -79,6 +84,18 @@ class SearchToolUsed(EvalBase):
     """Span-based: verify that search tools were called during agent execution."""
 
     def evaluate(self, ctx: EvalCtx) -> dict[str, bool | int]:
+        activity_names = _activity_tool_names(ctx)
+        activity_searches = [
+            name
+            for name in activity_names
+            if name in ("perplexity_search", "parallel_search")
+        ]
+        if activity_searches:
+            return {
+                "used_search": True,
+                "search_count": len(activity_searches),
+            }
+
         tree = _get_span_tree(ctx)
         if tree is None:
             return {"used_search": False, "search_count": 0}
@@ -102,6 +119,10 @@ class FetchUrlUsed(EvalBase):
     """Span-based: check if fetch_url tool was called during agent execution."""
 
     def evaluate(self, ctx: EvalCtx) -> dict[str, bool | int]:
+        activity_count = _activity_tool_names(ctx).count("fetch_url")
+        if activity_count:
+            return {"used_fetch": True, "fetch_count": activity_count}
+
         tree = _get_span_tree(ctx)
         if tree is None:
             return {"used_fetch": False, "fetch_count": 0}
@@ -142,10 +163,33 @@ class MultiPassProgression(EvalBase):
         }
 
 
+@dataclass
+class NotificationDecision(EvalBase):
+    """Assert trigger/no-trigger behavior against reviewed case ground truth."""
+
+    def evaluate(self, ctx: EvalCtx) -> EvaluationReason:
+        metadata = ctx.metadata
+        if metadata is None or metadata.expected_notification is None:
+            raise ValueError(
+                "NotificationDecision requires expected_notification metadata"
+            )
+
+        actual = ctx.output.notification is not None
+        expected = metadata.expected_notification
+        return EvaluationReason(
+            value=actual == expected,
+            reason=(
+                f"expected notification={expected}, actual={actual}; "
+                f"ground truth: {metadata.ground_truth or 'not provided'}"
+            ),
+        )
+
+
 CUSTOM_EVALUATORS = [
     SourcesWhenNotifying,
     ReasonableNextRun,
     SearchToolUsed,
     FetchUrlUsed,
     MultiPassProgression,
+    NotificationDecision,
 ]

--- a/torale-agent/evals/evaluators.py
+++ b/torale-agent/evals/evaluators.py
@@ -33,7 +33,7 @@ class SourcesWhenNotifying(EvalBase):
     """When a notification is sent, sources must be non-empty."""
 
     def evaluate(self, ctx: EvalCtx) -> bool:
-        if ctx.output.notification is None:
+        if not ctx.output.notification:
             return True
         return len(ctx.output.sources) > 0
 
@@ -174,7 +174,7 @@ class NotificationDecision(EvalBase):
                 "NotificationDecision requires expected_notification metadata"
             )
 
-        actual = ctx.output.notification is not None
+        actual = bool(ctx.output.notification)
         expected = metadata.expected_notification
         return EvaluationReason(
             value=actual == expected,

--- a/torale-agent/evals/models.py
+++ b/torale-agent/evals/models.py
@@ -24,6 +24,9 @@ class MonitoringCaseMetadata(BaseModel):
     category: str
     source: Literal["static", "dynamic"] = "static"
     generated_at: str | None = None
+    expected_notification: bool | None = None
+    ground_truth: str | None = None
+    ground_truth_as_of: str | None = None
 
 
 MonitoringCase = Case[MonitoringCaseInput, MonitoringResponse, MonitoringCaseMetadata]

--- a/torale-agent/evals/task.py
+++ b/torale-agent/evals/task.py
@@ -1,6 +1,7 @@
 """Task function for pydantic-evals: runs the monitoring agent against a case."""
 
 import re
+import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -14,6 +15,7 @@ from models import (
     MonitoringResponse,
     create_clients,
 )
+from tools import extract_activity
 
 from evals.models import MonitoringCaseInput
 
@@ -21,19 +23,22 @@ from evals.models import MonitoringCaseInput
 _eval_model: str = DEFAULT_MODEL
 _eval_clients: Clients | None = None
 _eval_agent: Agent[MonitoringDeps, MonitoringResponse] | None = None
+_eval_run_id: str | None = None
 
 
 @asynccontextmanager
 async def configure_eval(model: str) -> AsyncIterator[None]:
     """Set up shared agent and clients for an eval run, tear down after."""
-    global _eval_model, _eval_clients, _eval_agent
+    global _eval_model, _eval_clients, _eval_agent, _eval_run_id
     _eval_model = model
+    _eval_run_id = uuid.uuid4().hex[:12]
     _eval_agent = create_monitoring_agent(model)
     async with create_clients() as clients:
         _eval_clients = clients
         yield
         _eval_clients = None
         _eval_agent = None
+        _eval_run_id = None
 
 
 def _build_prompt(case: MonitoringCaseInput, history_block: str = "") -> str:
@@ -86,9 +91,13 @@ async def run_monitoring_task(case_input: MonitoringCaseInput) -> MonitoringResp
     """
     assert _eval_agent is not None, "call configure_eval() before running tasks"
     assert _eval_clients is not None, "call configure_eval() before running tasks"
+    assert _eval_run_id is not None, "call configure_eval() before running tasks"
 
-    task_id = f"eval-{_slugify(case_input.search_query[:50])}"
-    deps = MonitoringDeps(user_id="eval-user", task_id=task_id, clients=_eval_clients)
+    model_slug = _slugify(_eval_model)[:24]
+    task_slug = _slugify(case_input.search_query[:50])
+    namespace = f"eval-{model_slug}-{_eval_run_id}"
+    task_id = f"{namespace}-{task_slug}"
+    deps = MonitoringDeps(user_id=namespace, task_id=task_id, clients=_eval_clients)
 
     history_block = ""
     response: MonitoringResponse | None = None
@@ -97,6 +106,9 @@ async def run_monitoring_task(case_input: MonitoringCaseInput) -> MonitoringResp
         prompt = _build_prompt(case_input, history_block)
         result = await _eval_agent.run(prompt, deps=deps)
         response = result.output
+        activity = extract_activity(result.all_messages())
+        if activity:
+            response.activity = activity
 
         if pass_num < case_input.passes:
             history_block = _format_execution_history(response, pass_num)

--- a/torale-agent/models.py
+++ b/torale-agent/models.py
@@ -11,7 +11,7 @@ from parallel import AsyncParallel
 from perplexity import AsyncPerplexity
 from pydantic import BaseModel, ConfigDict, Field
 
-DEFAULT_MODEL = "google:gemini-3.1-flash-lite-preview"
+DEFAULT_MODEL = "google:gemini-3.5-flash-lite"
 
 
 class ToolAnnotations(BaseModel):

--- a/torale-agent/tests/test_evals.py
+++ b/torale-agent/tests/test_evals.py
@@ -85,6 +85,18 @@ def test_notification_decision_catches_false_positive():
     assert NotificationDecision().evaluate(ctx).value is False
 
 
+def test_empty_notification_matches_production_no_trigger_semantics():
+    ctx = _context(
+        output=_response(notification=""),
+        metadata=MonitoringCaseMetadata(
+            category="Tech",
+            expected_notification=False,
+        ),
+    )
+
+    assert NotificationDecision().evaluate(ctx).value is True
+
+
 def test_static_dataset_loads_decision_regressions():
     dataset = load_dataset(Path(__file__).parents[1] / "evals" / "cases.yaml")
     decision_cases = [

--- a/torale-agent/tests/test_evals.py
+++ b/torale-agent/tests/test_evals.py
@@ -1,0 +1,109 @@
+"""Regression tests for the monitoring evaluation harness."""
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from evals.dynamic import generate_webpage_cases
+from evals.evaluators import FetchUrlUsed, NotificationDecision, SearchToolUsed
+from evals.models import MonitoringCaseInput, MonitoringCaseMetadata
+from evals.runner import load_dataset
+from models import ActivityStep, MonitoringResponse
+from pydantic_evals.evaluators import EvaluatorContext
+from pydantic_evals.otel._errors import SpanTreeRecordingError
+
+
+def _response(*, notification: str | None, tools: list[str] | None = None):
+    return MonitoringResponse(
+        evidence="Reviewed evidence",
+        sources=["https://example.com/source"],
+        confidence=90,
+        next_run="2026-08-09T12:00:00Z",
+        notification=notification,
+        activity=[ActivityStep(tool=tool, detail="query") for tool in (tools or [])],
+    )
+
+
+def _context(
+    *, output: MonitoringResponse, metadata: MonitoringCaseMetadata
+) -> EvaluatorContext[MonitoringCaseInput, MonitoringResponse, MonitoringCaseMetadata]:
+    return EvaluatorContext(
+        name="test",
+        inputs=MonitoringCaseInput(
+            search_query="test query",
+            condition_description="test condition",
+            category="Tech",
+        ),
+        metadata=metadata,
+        expected_output=None,
+        output=output,
+        duration=0.1,
+        _span_tree=SpanTreeRecordingError("not recorded"),
+        attributes={},
+        metrics={},
+    )
+
+
+def test_search_tool_evaluator_uses_production_activity():
+    ctx = _context(
+        output=_response(
+            notification=None, tools=["perplexity_search", "final_result"]
+        ),
+        metadata=MonitoringCaseMetadata(category="Tech"),
+    )
+
+    assert SearchToolUsed().evaluate(ctx) == {"used_search": True, "search_count": 1}
+
+
+def test_notification_decision_matches_reviewed_ground_truth():
+    ctx = _context(
+        output=_response(notification="Condition met"),
+        metadata=MonitoringCaseMetadata(
+            category="Tech",
+            expected_notification=True,
+            ground_truth="The release is official.",
+        ),
+    )
+
+    result = NotificationDecision().evaluate(ctx)
+
+    assert result.value is True
+    assert "expected notification=True" in (result.reason or "")
+
+
+def test_notification_decision_catches_false_positive():
+    ctx = _context(
+        output=_response(notification="Incorrect trigger"),
+        metadata=MonitoringCaseMetadata(
+            category="Tech",
+            expected_notification=False,
+            ground_truth="The release does not exist.",
+        ),
+    )
+
+    assert NotificationDecision().evaluate(ctx).value is False
+
+
+def test_static_dataset_loads_decision_regressions():
+    dataset = load_dataset(Path(__file__).parents[1] / "evals" / "cases.yaml")
+    decision_cases = [
+        case
+        for case in dataset.cases
+        if case.metadata is not None and case.metadata.expected_notification is not None
+    ]
+
+    assert len(decision_cases) == 4
+    assert all(
+        any(isinstance(e, NotificationDecision) for e in c.evaluators)
+        for c in decision_cases
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_assertion_is_scoped_to_webpage_cases():
+    async with httpx.AsyncClient() as client:
+        cases = await generate_webpage_cases(client)
+
+    assert cases
+    assert all(any(isinstance(e, FetchUrlUsed) for e in c.evaluators) for c in cases)


### PR DESCRIPTION
## Summary

- replace the retired Gemini 3.1 Flash-Lite preview with stable Gemini 3.5 Flash-Lite
- add reviewed trigger/no-trigger ground truth and production-shaped tool activity to Pydantic Evals
- isolate evaluation memory, fix dynamic stock and fetch assertions, and add a reproducible `--decision-only` gate

## Evidence

- durable decisions: 4/4; 95.8% assertions; 15.5s mean
- fresh finance decisions: 6/6; 100% applicable assertions; 14.9s mean
- incumbent preview: 4/4; 91.7% assertions; 15.4s mean
- Gemini 3.6 Flash: materially slower (49.5s observed) and 3-5x the price; quota prevented a complete comparison

## Validation

- `just lint`
- `just test` (222 backend passed, 30 skipped; 15 agent passed)
- `docker build -t webwhen-agent:model-eval ./torale-agent`

## Rollout

Staging smoke test before marking ready; merge only after Codex review is clean.