### PR TITLE
fix: load watches after authentication

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { Plus } from 'lucide-react'
 import { toast } from 'sonner'
@@ -46,7 +46,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ onTaskClick }) => {
   const [editTask, setEditTask] = useState<Task | null>(null)
   const [showWelcome, setShowWelcome] = useState(false)
 
-  const loadTasks = async () => {
+  const loadTasks = useCallback(async () => {
     setIsLoading(true)
     try {
       const data = await api.getTasks()
@@ -57,11 +57,16 @@ export const Dashboard: React.FC<DashboardProps> = ({ onTaskClick }) => {
     } finally {
       setIsLoading(false)
     }
-  }
+  }, [])
 
   useEffect(() => {
+    // On the first render after Clerk redirects back from sign-in, the API
+    // client may not have its token getter yet. Waiting for the backend user
+    // also makes this effect rerun once authentication setup is complete.
+    if (!isLoaded || !user) return
+
     loadTasks()
-  }, [])
+  }, [isLoaded, user, loadTasks])
 
   useEffect(() => {
     if (isLoaded && user && user.has_seen_welcome === false) {


### PR DESCRIPTION
## What changed

- Wait for the authenticated backend user before loading watches.
- Rerun the dashboard fetch when authentication setup completes.

## Why

Immediately after sign-in, the dashboard mounted before the shared API client had received its Clerk token getter. The first tasks request was therefore unauthenticated and returned `401`, leaving the watch list empty until the user navigated away and back.

## Impact

Watches now load on the first dashboard render after login.

## Validation

- Reproduced the production request sequence with a signed-in browser profile: initial tasks request returned `401` without an authorization header; a later navigation sent the token and returned `200`.
- `npm run typecheck`
- Targeted Next.js lint for `src/components/Dashboard.tsx`
- `git diff --check`

Repository-wide `just lint` reaches unrelated in-progress eval changes and currently stops on type diagnostics in `torale-agent/tests/test_evals.py`.