### PR TITLE
refactor: simplify Pydantic AI runtime contracts

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -6,3 +6,4 @@
 - [project_execution_id_reuse_legacy.md](project_execution_id_reuse_legacy.md) - Pre-PR#207 rows have inflated durations and stale errors; don't backfill, they age out
 - [project_notification_links.md](project_notification_links.md) - Notification CTAs are owner links; public `/tasks/:id` returns 404 for private watches
 - [project_watch_lifecycle.md](project_watch_lifecycle.md) - Watches are user-controlled; suppress agent auto-completion and guard rescheduling races
+- [project_search_retrieval.md](project_search_retrieval.md) - Search is independent from the reasoning model; Perplexity/Parallel replaced Gemini native grounding based on evals

--- a/.claude/memory/project_search_retrieval.md
+++ b/.claude/memory/project_search_retrieval.md
@@ -1,0 +1,8 @@
+# Search retrieval is independent from the reasoning model
+
+- webwhen deliberately does not use Gemini native Google Search grounding in production.
+- The November 2025 grounded-search evaluation selected Perplexity: 80% accuracy versus 60% for Gemini Grounded on the recorded cases (PR #34, commit `687fdc2`).
+- The January 2026 agent migration made this an architectural boundary: Gemini reasons while explicit Perplexity tools retrieve evidence (PR #136, commit `aa221a0`).
+- Parallel was added in March 2026 because it surfaced different authoritative primary sources; its recorded eval passed 9/9 cases without notification-accuracy regression (PR #174, commit `3adb07e`).
+- Keep search providers as explicit, provider-shaped tools so model evals compare reasoning against the same retrieval layer. Do not adopt Pydantic AI/provider-native web search merely for convenience; require a webwhen-specific eval showing a material improvement.
+- Gemini grounding previously also required cleanup of Vertex redirect citation URLs, but that was secondary to the measured quality and architecture decisions.

--- a/docs-site/architecture/grounded-search.md
+++ b/docs-site/architecture/grounded-search.md
@@ -1,90 +1,62 @@
 ---
 title: Grounded Search
-description: How webwhen combines Google Search with LLM evaluation to watch for web conditions. Pydantic AI agent, Gemini grounding, source attribution, and condition evaluation.
+description: How webwhen keeps search retrieval independent from model reasoning while preserving typed evidence and source attribution.
 ---
 
 # Grounded Search
 
-webwhen watches for conditions on the open web by combining **live search results** with an **LLM that evaluates** whether the condition is met. The combination is called _grounded search_: answers are grounded in current search data rather than the model's training cutoff.
+webwhen combines live evidence with an LLM that decides whether a watch's condition has been met. Search and reasoning are deliberately separate: changing the reasoning model does not silently change how evidence is retrieved.
 
-::: tip Naming during the transition
-Internal modules are still under `torale-agent/` and `backend/src/torale/`. The product is now webwhen; module rename is a later phase.
-:::
+## Retrieval boundary
 
-## Why grounded search
+The Pydantic AI agent can choose among explicit tools defined in `torale-agent/tools.py`:
 
-A pure LLM cannot answer "did Apple announce an iPhone release date today?" — its training data is stale and it cannot browse. A pure scraper cannot answer "is the announced date before Q2 2027?" — it has no reasoning. webwhen's pipeline does both:
+- **Perplexity Search** — synthesized current results with citations and freshness metadata.
+- **Parallel Search** — structured result excerpts that often surface primary sources missed by aggregated search.
+- **Twitter Search** — recent public posts for announcements and fast-moving conversation.
+- **Fetch URL** — direct page content when a search excerpt is stale or incomplete.
 
-- **Current information** from Google Search at execution time
-- **Source attribution** — each answer cites the pages it came from
-- **Condition evaluation** — the LLM decides whether the user's condition is satisfied
-- **Execution awareness** — the agent knows when a watch last ran and focuses on what's new
+The primary reasoning model is Gemini, but webwhen does not use Gemini's native Google Search grounding. This is an evaluated product boundary rather than a framework limitation. A November 2025 comparison found Perplexity more accurate for webwhen's monitoring cases, and Parallel was later added after it improved primary-source coverage without reducing trigger accuracy.
 
-## Pipeline
+Keeping retrieval explicit also means an eval can compare reasoning models against the same evidence tools. Provider-native search should only replace this boundary after a monitoring-specific evaluation shows a material improvement.
 
-Each execution runs the following loop inside the agent:
+## Execution loop
 
-1. **Search.** The agent issues Google Search queries (via Gemini's built-in grounding, and/or Parallel Search for broader coverage) derived from the user's `search_query`.
-2. **Read.** Top results are fetched and excerpted. The agent can follow citations when extra context is needed.
-3. **Reason.** Using the gathered evidence, the agent writes a short, user-readable answer to the query.
-4. **Evaluate.** The agent decides whether the user's `condition_description` is satisfied based on the answer + evidence.
-5. **Attribute.** The agent returns a structured response with the answer, reasoning, and a filtered list of source URLs.
+Each run follows the same evidence-driven loop:
 
-The output is a typed `MonitoringResponse` (see `torale-agent/models.py`) that the backend persists and optionally uses to fire a trigger.
+1. Review previous executions and task-specific search memories.
+2. Select an appropriate search tool and query for current information.
+3. Fetch promising source pages when snippets are insufficient.
+4. Compare new evidence with the user's condition and prior notifications.
+5. Return a typed `MonitoringResponse` containing evidence, source URLs, confidence, an optional notification, and the next run time.
 
-## Agent runtime
+Search and fetch tools return typed, provider-shaped results. Pydantic AI includes their return schemas in the tool definitions, so the model sees the actual fields without webwhen flattening provider capabilities into a lowest-common-denominator result.
 
-The agent is built with [Pydantic AI](https://ai.pydantic.dev/) on top of Gemini (primary) with graceful degradation to the paid tier when the free tier returns a 503 under load (see `backend/src/torale/scheduler/`).
+## Runtime guardrails
 
-Two capabilities drive the loop:
+Pydantic AI enforces per-run limits of 20 model requests, 40 tool calls, and 100,000 total tokens. Each successful production, CLI, and evaluation run emits request, tool-call, and token usage to Logfire in addition to the normal Pydantic AI spans.
 
-- **Google grounding** — Gemini's native search integration returns results with citations the agent can reason over.
-- **Tools** — defined in `torale-agent/tools.py`. Include parallel search (multi-query web search), page fetch (read a specific URL), and activity logging (so the frontend can replay the agent's steps).
-
-The agent runs with `retries=3` and, on supported models, extended thinking enabled.
-
-## Source filtering
-
-Gemini's grounding responses sometimes include Vertex AI redirect URLs rather than the actual source page. Before returning a result, the backend filters these out so the user sees canonical domains (for example, `apple.com`) in triggers rather than `vertexaisearch.cloud.google.com/...` redirects.
+Perplexity and Parallel retain their SDK-native bounded HTTP retries. Direct page fetching has a hard timeout and returns a structured failure the agent can act on.
 
 ## Response shape
 
-A completed execution returns:
+The agent and backend share this application contract:
 
 ```json
 {
-  "condition_met": true,
-  "answer": "Apple announced iPhone 17 will be released on September 19, 2026. Pre-orders begin September 12.",
-  "reasoning": "Apple's official newsroom post confirms a specific release date, satisfying the condition.",
-  "sources": [
-    { "uri": "https://www.apple.com/newsroom/…", "title": "Apple announces iPhone 17" }
-  ],
-  "next_run": "2026-09-20T00:00:00Z"
+  "evidence": "Apple's newsroom confirms a specific release date.",
+  "sources": ["https://www.apple.com/newsroom/…"],
+  "confidence": 96,
+  "next_run": "2026-09-20T00:07:00Z",
+  "notification": "Apple announced the iPhone 17 release date as September 19.",
+  "topic": "iPhone 17 release date",
+  "activity": []
 }
 ```
 
-`next_run` drives the scheduler. When the agent returns `next_run=null`, the backend transitions the watch to `completed` (see [Watch State Machine](/architecture/task-state-machine)).
-
-## Execution context
-
-The backend passes execution context to the agent each run:
-
-- `last_executed_at` — so the agent can prioritise _new_ information since the last check
-- `previous_answer` — so small phrasing changes don't fire false-positive triggers
-- `notify_behavior` — `once` vs `always`, which affects how aggressively the agent declares a match
-
-This context plus typed outputs is what distinguishes webwhen from a plain cron + LLM setup.
-
-## Tuning the query
-
-The query and condition are independent knobs. A good query is specific and search-engine-shaped; a good condition is objectively evaluable.
-
-- Query: "iPhone 17 release date announcement"
-- Condition: "Apple has publicly stated a specific release date"
-
-If impressions look high but the agent reports no match, the condition is probably too strict. If matches happen every run, the condition is too loose.
+`notification` is omitted when there is nothing worth telling the user. `next_run` remains populated because watch lifecycle changes belong to the user or an administrator, not to an individual agent run. If the model nevertheless returns `null`, the backend schedules a fallback rather than completing the watch.
 
 ## Related
 
-- [Self-Scheduling Agents](/architecture/self-scheduling-agents) — how the agent, scheduler, and grounded search compose into a self-driving watch loop
-- [Watch State Machine](/architecture/task-state-machine) — how execution is scheduled and terminated
+- [Self-Scheduling Agents](/architecture/self-scheduling-agents) — how evidence gathering composes with scheduling
+- [Watch State Machine](/architecture/task-state-machine) — user-controlled watch lifecycle

--- a/docs-site/architecture/self-scheduling-agents.md
+++ b/docs-site/architecture/self-scheduling-agents.md
@@ -22,56 +22,51 @@ flowchart LR
     C --> D[Agent: Pydantic AI + Gemini]
     D --> E[Grounded search + fetch tools]
     E --> F[Typed MonitoringResponse]
-    F --> G{condition_met?}
+    F --> G{notification?}
     G -->|yes| H[Fire trigger]
     G -->|no| I[Skip]
-    H --> J{next_run?}
+    H --> J[Reschedule APScheduler job]
     I --> J
-    J -->|timestamp| K[Reschedule APScheduler job]
-    J -->|null| L[Transition watch to completed]
-    K --> A
+    J --> A
 ```
 
 ## Components
 
 | Component | Lives in | Role |
 | --- | --- | --- |
-| Scheduler | `backend/src/torale/scheduler/` | APScheduler instance. Fires cron ticks, picks up watches, reschedules based on agent output. |
+| Scheduler | `backend/src/webwhen/scheduler/` | APScheduler instance. Picks up watches and reschedules from agent output. |
 | Agent service | `torale-agent/agent.py`, `torale-agent/server.py` | Pydantic AI agent behind an A2A-protocol server. Stateless per-execution. |
-| Tools | `torale-agent/tools.py` | Parallel search, page fetch, activity logging. The agent decides which to call. |
-| Watch state | `backend/src/torale/tasks/tasks.py`, `.../service.py` | Three-state enum (active/paused/completed) guarded by a state machine. |
+| Tools | `torale-agent/tools.py` | Perplexity, Parallel, Twitter, page fetch, memory, and connected read tools. The agent decides which to call. |
+| Watch state | `backend/src/webwhen/tasks/tasks.py`, `.../service.py` | Three-state enum (active/paused/completed) controlled by users and administrators. |
 
 ## Execution contract
 
-The backend invokes the agent with a `MonitoringDeps` payload containing the watch's `search_query`, `condition_description`, `notify_behavior`, `last_executed_at`, and optional `previous_answer`. The agent returns a typed `MonitoringResponse`:
+The backend sends the watch prompt and execution history over A2A. `MonitoringDeps` carries the user ID, watch ID, and scoped service clients. The agent returns a typed `MonitoringResponse`:
 
 ```python
 class MonitoringResponse(BaseModel):
-    condition_met: bool
-    answer: str                   # short, user-readable
-    reasoning: str                # why the agent decided as it did
-    sources: list[Source]         # filtered citations
-    next_run: datetime | None     # None = watch complete
-    activity: list[ActivityStep]  # replayable trace for the UI
+    evidence: str
+    sources: list[str]
+    confidence: int
+    next_run: str | None
+    notification: str | None
+    topic: str | None
+    activity: list[ActivityStep] | None
 ```
 
 This schema is duplicated between `torale-agent/models.py` and `backend/src/torale/scheduler/models.py` (see the note in `CLAUDE.md`). Both must stay in sync.
 
 ## Scheduling semantics
 
-Two behaviours matter:
+The agent is the source of truth for cadence, but not lifecycle. It should always return a future `next_run`, including after a trigger. Execution history helps it avoid sending the same notification repeatedly.
 
-**`notify_behavior="once"`** — fire at most one trigger, then stop scheduling. When the agent returns `condition_met=true` with `next_run=null`, the backend fires the notification and transitions the watch to `completed` via the state machine.
-
-**`notify_behavior="always"`** — fire every time the condition is met. The agent returns a `next_run` even after matches, and the watch stays `active`. The backend uses `previous_answer` to suppress trivially-identical triggers.
-
-In both modes the agent is the source of truth for cadence. The backend doesn't hard-code "check every N minutes"; it only ever respects `next_run`.
+Only an explicit user or administrator action may pause or complete a watch. If an agent returns `next_run=null`, the backend records that request, suppresses completion, and schedules a fallback run. Scheduling also re-checks watch state so an in-flight execution cannot resurrect a concurrently paused watch.
 
 ## Why this shape
 
 - **Fewer false positives.** Grounded reasoning beats byte-diffs on dynamic pages.
 - **Fewer wasted checks.** An agent that just found "announcement expected next week" can schedule itself tighter; one that found nothing can back off.
-- **Clean termination.** A `notify_behavior="once"` watch stops scheduling itself the moment the condition holds. No zombie cron jobs, no per-watch TTL configuration.
+- **Safe continuity.** A single imperfect run cannot silently complete an ongoing watch.
 - **Replayable runs.** The `activity` array in each response is a trace of what the agent did — surfaced in the frontend watch detail view for debugging.
 
 ## Adding a new tool

--- a/torale-agent/README.md
+++ b/torale-agent/README.md
@@ -82,6 +82,10 @@ Static cases are stored in `evals/cases.yaml`. `uv run torale-agent eval generat
 
 The agent:
 1. Receives monitoring task parameters via A2A protocol
-2. Executes web search using Perplexity
+2. Selects explicit Perplexity, Parallel, Twitter, and direct-fetch evidence tools
 3. Analyzes results with LLM
 4. Returns structured response with evidence and confidence
+
+Search retrieval is intentionally independent from the reasoning model. Evidence
+tools return typed, provider-shaped results with Pydantic AI return schemas; the
+agent does not use Gemini native Google Search grounding.

--- a/torale-agent/cli.py
+++ b/torale-agent/cli.py
@@ -11,6 +11,7 @@ from rich.table import Table
 
 from agent import OutputMode, create_monitoring_agent
 from models import DEFAULT_MODEL, MonitoringDeps, create_clients
+from runtime import MONITORING_USAGE_LIMITS, record_run_usage
 
 app = typer.Typer(help="Torale Agent Evaluation CLI")
 eval_app = typer.Typer(help="Run and manage evaluations")
@@ -64,7 +65,10 @@ async def _query_async(
             deps = MonitoringDeps(
                 user_id="cli-user", task_id="cli-query", clients=clients
             )
-            result = await agent.run(prompt, deps=deps)
+            result = await agent.run(
+                prompt, deps=deps, usage_limits=MONITORING_USAGE_LIMITS
+            )
+            record_run_usage(result, operation="cli", model=model)
             latency_ms = (time.perf_counter() - start_time) * 1000
 
             output_json = result.output.model_dump_json(indent=2)

--- a/torale-agent/evals/task.py
+++ b/torale-agent/evals/task.py
@@ -16,6 +16,7 @@ from models import (
     create_clients,
 )
 from tools import extract_activity
+from runtime import MONITORING_USAGE_LIMITS, record_run_usage
 
 from evals.models import MonitoringCaseInput
 
@@ -112,7 +113,15 @@ async def run_monitoring_task(case_input: MonitoringCaseInput) -> MonitoringResp
 
     for pass_num in range(1, case_input.passes + 1):
         prompt = _build_prompt(case_input, history_block)
-        result = await _eval_agent.run(prompt, deps=deps)
+        result = await _eval_agent.run(
+            prompt, deps=deps, usage_limits=MONITORING_USAGE_LIMITS
+        )
+        record_run_usage(
+            result,
+            operation="eval",
+            model=_eval_model,
+            case=case_input.search_query,
+        )
         response = result.output
         activity = extract_activity(result.all_messages())
         if activity:

--- a/torale-agent/models.py
+++ b/torale-agent/models.py
@@ -22,6 +22,51 @@ class ToolAnnotations(BaseModel):
     idempotentHint: bool | None = None
 
 
+class ToolError(BaseModel):
+    """Structured failure returned to the model when a tool cannot produce data."""
+
+    error: str
+
+
+class PerplexitySearchResult(BaseModel):
+    """One result returned by Perplexity's search API."""
+
+    title: str
+    url: str
+    snippet: str
+    date: str | None = None
+    last_updated: str | None = None
+
+
+class ParallelSearchResult(BaseModel):
+    """One result returned by Parallel's search API."""
+
+    title: str
+    url: str
+    excerpts: list[str] = Field(default_factory=list)
+
+
+class TwitterSearchResult(BaseModel):
+    """One result returned by the Twitter search API."""
+
+    text: str
+    author: str
+    url: str
+    likes: int
+    retweets: int
+    created_at: str
+
+
+class FetchResult(BaseModel):
+    """Content extracted from a URL, or a structured fetch failure."""
+
+    url: str
+    content: str | None = None
+    content_length: int | None = None
+    truncated: bool | None = None
+    error: str | None = None
+
+
 class ActivityStep(BaseModel):
     """A single step the agent took during monitoring.
 

--- a/torale-agent/runtime.py
+++ b/torale-agent/runtime.py
@@ -1,0 +1,32 @@
+"""Shared runtime policy for production, CLI, and evaluation agent runs."""
+
+from typing import Any
+
+import logfire
+from pydantic_ai import AgentRunResult
+from pydantic_ai.usage import UsageLimits
+
+
+MONITORING_USAGE_LIMITS = UsageLimits(
+    request_limit=20,
+    tool_calls_limit=40,
+    total_tokens_limit=100_000,
+)
+"""High enough for deliberate research, low enough to stop a runaway tool loop."""
+
+
+def record_run_usage(
+    result: AgentRunResult[Any], *, operation: str, **context: str
+) -> None:
+    """Emit a compact per-run usage event in addition to Pydantic AI spans."""
+    usage = result.usage
+    logfire.info(
+        "Monitoring agent run usage",
+        operation=operation,
+        requests=usage.requests,
+        tool_calls=usage.tool_calls,
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        total_tokens=usage.total_tokens,
+        context=context,
+    )

--- a/torale-agent/server.py
+++ b/torale-agent/server.py
@@ -37,6 +37,7 @@ from starlette.routing import Route
 
 from agent import create_monitoring_agent
 from models import Clients, MonitoringDeps, MonitoringResponse, create_clients
+from runtime import MONITORING_USAGE_LIMITS, record_run_usage
 from tools import extract_activity
 
 load_dotenv()
@@ -205,6 +206,13 @@ class ToraleAgentExecutor(AgentExecutor):
                 user_input,
                 deps=deps,
                 toolsets=mcp_toolsets or None,
+                usage_limits=MONITORING_USAGE_LIMITS,
+            )
+            record_run_usage(
+                result,
+                operation="a2a",
+                task_id=monitoring_task_id,
+                user_id=user_id,
             )
             response = result.output
 

--- a/torale-agent/tests/test_evals.py
+++ b/torale-agent/tests/test_evals.py
@@ -15,6 +15,7 @@ from models import ActivityStep, MonitoringResponse
 from pydantic_ai.models.google import GoogleModelSettings
 from pydantic_evals.evaluators import EvaluatorContext
 from pydantic_evals.otel._errors import SpanTreeRecordingError
+from runtime import MONITORING_USAGE_LIMITS
 
 
 def _response(*, notification: str | None, tools: list[str] | None = None):
@@ -121,7 +122,7 @@ def test_agent_can_override_gemini_thinking_level():
     )
 
     settings = cast(GoogleModelSettings, agent.model_settings)
-    assert settings["thinking"] == "medium"
+    assert settings.get("thinking") == "medium"
 
 
 def test_agent_reads_gemini_thinking_level_from_environment(monkeypatch):
@@ -130,7 +131,7 @@ def test_agent_reads_gemini_thinking_level_from_environment(monkeypatch):
     agent = create_monitoring_agent("google:gemini-3.5-flash-lite")
 
     settings = cast(GoogleModelSettings, agent.model_settings)
-    assert settings["thinking"] == "low"
+    assert settings.get("thinking") == "low"
 
 
 def test_agent_defaults_to_minimal_gemini_thinking(monkeypatch):
@@ -139,7 +140,7 @@ def test_agent_defaults_to_minimal_gemini_thinking(monkeypatch):
     agent = create_monitoring_agent("google:gemini-3.5-flash-lite")
 
     settings = cast(GoogleModelSettings, agent.model_settings)
-    assert settings["thinking"] == "minimal"
+    assert settings.get("thinking") == "minimal"
 
 
 def test_other_gemini_models_keep_high_thinking_default(monkeypatch):
@@ -148,7 +149,7 @@ def test_other_gemini_models_keep_high_thinking_default(monkeypatch):
     agent = create_monitoring_agent("google:gemini-3-pro")
 
     settings = cast(GoogleModelSettings, agent.model_settings)
-    assert settings["thinking"] == "high"
+    assert settings.get("thinking") == "high"
 
 
 def test_always_on_gemini_model_rejects_minimal_thinking():
@@ -173,6 +174,27 @@ def test_openai_compatible_models_default_to_tool_structured_output():
     agent = create_monitoring_agent("openai-chat:gpt-4o-mini")
 
     assert type(agent._output_schema).__name__ == "ToolOutputSchema"
+
+
+def test_evidence_tools_expose_typed_return_schemas():
+    agent = create_monitoring_agent()
+
+    for name in (
+        "perplexity_search",
+        "parallel_search",
+        "twitter_search",
+        "fetch_url",
+    ):
+        tool = agent._function_toolset.tools[name]
+        assert tool.include_return_schema is True
+        assert tool.function_schema is not None
+        assert tool.function_schema.return_schema is not None
+
+
+def test_monitoring_usage_policy_bounds_runaway_agent_loops():
+    assert MONITORING_USAGE_LIMITS.request_limit == 20
+    assert MONITORING_USAGE_LIMITS.tool_calls_limit == 40
+    assert MONITORING_USAGE_LIMITS.total_tokens_limit == 100_000
 
 
 def test_model_output_mode_can_be_read_from_environment(monkeypatch):

--- a/torale-agent/tests/test_server.py
+++ b/torale-agent/tests/test_server.py
@@ -23,6 +23,7 @@ from pydantic_ai.exceptions import ModelHTTPError
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.toolsets import AbstractToolset, ToolsetTool
+from pydantic_ai.usage import RunUsage
 
 import server
 from models import MonitoringResponse
@@ -64,7 +65,11 @@ def make_context(metadata=None):
 
 
 def successful_agent():
-    result = SimpleNamespace(output=RESPONSE, all_messages=lambda: [])
+    result = SimpleNamespace(
+        output=RESPONSE,
+        all_messages=lambda: [],
+        usage=RunUsage(requests=2, tool_calls=1, input_tokens=100, output_tokens=25),
+    )
     agent = MagicMock()
     agent.run = AsyncMock(return_value=result)
     return agent
@@ -86,6 +91,9 @@ async def test_success_emits_initial_task_before_updates():
         RESPONSE.model_dump(mode="json")
     ]
     assert queue.events[3].status.state == TaskState.TASK_STATE_COMPLETED
+    run_mock = cast(AsyncMock, executor.agent.run)
+    assert run_mock.await_args is not None
+    assert run_mock.await_args.kwargs["usage_limits"].request_limit == 20
 
 
 @pytest.mark.asyncio

--- a/torale-agent/tools.py
+++ b/torale-agent/tools.py
@@ -10,9 +10,20 @@ import httpx
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.messages import ModelResponse, ToolCallPart
 
-from models import ActivityStep, Clients, MonitoringDeps, MonitoringResponse
+from models import (
+    ActivityStep,
+    Clients,
+    FetchResult,
+    MonitoringDeps,
+    MonitoringResponse,
+    ParallelSearchResult,
+    PerplexitySearchResult,
+    ToolError,
+    TwitterSearchResult,
+)
 
 _NO_CLIENTS = json.dumps({"error": "No context available"})
+_NO_CLIENTS_ERROR = ToolError(error="No context available")
 
 
 def _get_clients(ctx: RunContext[MonitoringDeps]) -> Clients | None:
@@ -79,10 +90,10 @@ async def _is_safe_url(url: str) -> bool:
         return False
 
 
-async def _fetch_and_extract(url: str) -> dict:
+async def _fetch_and_extract(url: str) -> FetchResult:
     """Fetch a URL using Lightpanda headless browser and return content as markdown."""
     if not await _is_safe_url(url):
-        return {"url": url, "error": "URL blocked: private or internal address"}
+        return FetchResult(url=url, error="URL blocked: private or internal address")
 
     proc = await asyncio.create_subprocess_exec(
         "lightpanda",
@@ -104,13 +115,13 @@ async def _fetch_and_extract(url: str) -> dict:
     except asyncio.TimeoutError:
         proc.kill()
         await proc.wait()
-        return {"url": url, "error": "Fetch timed out"}
+        return FetchResult(url=url, error="Fetch timed out")
 
     if proc.returncode != 0:
         error_msg = (
             stderr.decode().strip() if stderr else f"Exit code {proc.returncode}"
         )
-        return {"url": url, "error": error_msg}
+        return FetchResult(url=url, error=error_msg)
 
     content = stdout.decode()
     content = "\n".join(line for line in content.splitlines() if line.strip())
@@ -118,12 +129,12 @@ async def _fetch_and_extract(url: str) -> dict:
     full_length = len(content)
     truncated = full_length > FETCH_MAX_CHARS
 
-    return {
-        "url": url,
-        "content": content[:FETCH_MAX_CHARS],
-        "content_length": full_length,
-        "truncated": truncated,
-    }
+    return FetchResult(
+        url=url,
+        content=content[:FETCH_MAX_CHARS],
+        content_length=full_length,
+        truncated=truncated,
+    )
 
 
 def register_tools(agent: Agent[MonitoringDeps, MonitoringResponse]) -> None:
@@ -155,29 +166,32 @@ def register_tools(agent: Agent[MonitoringDeps, MonitoringResponse]) -> None:
         )
         return json.dumps(result, default=str)
 
-    @agent.tool
-    async def perplexity_search(ctx: RunContext[MonitoringDeps], query: str) -> str:
+    @agent.tool(include_return_schema=True)
+    async def perplexity_search(
+        ctx: RunContext[MonitoringDeps], query: str
+    ) -> list[PerplexitySearchResult] | ToolError:
         """Search the web using Perplexity for current information. Include the current year in queries for time-sensitive topics."""
         if (clients := _get_clients(ctx)) is None:
-            return _NO_CLIENTS
+            return _NO_CLIENTS_ERROR
         response = await clients.perplexity.search.create(query=query)
-        results = [
-            {
-                "title": r.title,
-                "url": r.url,
-                "snippet": r.snippet,
-                "date": r.date,
-                "last_updated": r.last_updated,
-            }
+        return [
+            PerplexitySearchResult(
+                title=r.title,
+                url=r.url,
+                snippet=r.snippet,
+                date=r.date,
+                last_updated=r.last_updated,
+            )
             for r in response.results
         ]
-        return json.dumps(results)
 
-    @agent.tool
-    async def parallel_search(ctx: RunContext[MonitoringDeps], query: str) -> str:
+    @agent.tool(include_return_schema=True)
+    async def parallel_search(
+        ctx: RunContext[MonitoringDeps], query: str
+    ) -> list[ParallelSearchResult] | ToolError:
         """Search the web using Parallel for current information. Returns structured results with URLs, titles, and content excerpts. Often finds different authoritative sources than Perplexity."""
         if (clients := _get_clients(ctx)) is None:
-            return _NO_CLIENTS
+            return _NO_CLIENTS_ERROR
         result = await clients.parallel.beta.search(
             objective=query,
             search_queries=[query],
@@ -185,23 +199,24 @@ def register_tools(agent: Agent[MonitoringDeps, MonitoringResponse]) -> None:
             max_chars_per_result=PARALLEL_SEARCH_MAX_CHARS,
             betas=PARALLEL_SEARCH_BETAS,
         )
-        results = [
-            {
-                "title": r.title,
-                "url": r.url,
-                "excerpts": r.excerpts[:PARALLEL_SEARCH_MAX_EXCERPTS]
+        return [
+            ParallelSearchResult(
+                title=r.title or r.url,
+                url=r.url,
+                excerpts=r.excerpts[:PARALLEL_SEARCH_MAX_EXCERPTS]
                 if r.excerpts
                 else [],
-            }
+            )
             for r in (result.results or [])
         ]
-        return json.dumps(results)
 
-    @agent.tool
-    async def twitter_search(ctx: RunContext[MonitoringDeps], query: str) -> str:
+    @agent.tool(include_return_schema=True)
+    async def twitter_search(
+        ctx: RunContext[MonitoringDeps], query: str
+    ) -> list[TwitterSearchResult] | ToolError:
         """Search Twitter/X for recent tweets. Best for real-time public reactions, social sentiment, and announcements posted on Twitter. Uses Twitter's advanced search syntax (e.g. 'from:user', 'min_faves:10')."""
         if (clients := _get_clients(ctx)) is None:
-            return _NO_CLIENTS
+            return _NO_CLIENTS_ERROR
         try:
             resp = await clients.twitter.get(
                 "/twitter/tweet/advanced_search",
@@ -210,30 +225,28 @@ def register_tools(agent: Agent[MonitoringDeps, MonitoringResponse]) -> None:
             resp.raise_for_status()
             tweets = resp.json().get("tweets", [])
         except httpx.HTTPStatusError as e:
-            return json.dumps({"error": f"Twitter API error: {e.response.status_code}"})
+            return ToolError(error=f"Twitter API error: {e.response.status_code}")
         except json.JSONDecodeError:
-            return json.dumps({"error": "Failed to decode response from Twitter API"})
-        results = [
-            {
-                "text": t.get("text", ""),
-                "author": t.get("author", {}).get("userName", ""),
-                "url": t.get("url", ""),
-                "likes": t.get("likeCount", 0),
-                "retweets": t.get("retweetCount", 0),
-                "created_at": t.get("createdAt", ""),
-            }
+            return ToolError(error="Failed to decode response from Twitter API")
+        return [
+            TwitterSearchResult(
+                text=t.get("text", ""),
+                author=t.get("author", {}).get("userName", ""),
+                url=t.get("url", ""),
+                likes=t.get("likeCount", 0),
+                retweets=t.get("retweetCount", 0),
+                created_at=t.get("createdAt", ""),
+            )
             for t in tweets[:TWITTER_SEARCH_MAX_RESULTS]
         ]
-        return json.dumps(results)
 
-    @agent.tool_plain
-    async def fetch_url(url: str) -> str:
+    @agent.tool_plain(include_return_schema=True)
+    async def fetch_url(url: str) -> FetchResult:
         """Fetch a URL directly and extract its content as markdown. Uses a headless browser, so JS-rendered pages work. Useful when search snippets are stale or you need to check the source."""
         try:
-            result = await _fetch_and_extract(url)
-            return json.dumps(result)
+            return await _fetch_and_extract(url)
         except Exception as e:
-            return json.dumps({"url": url, "error": str(e)})
+            return FetchResult(url=url, error=str(e))
 
 
 def extract_activity(messages: list) -> list[ActivityStep]:


### PR DESCRIPTION
## Summary

- keep the evaluated Perplexity/Parallel retrieval boundary independent from Gemini reasoning
- replace JSON-encoded evidence tool outputs with typed provider-shaped results and Pydantic AI return schemas
- apply shared request, tool-call, and token limits to production, CLI, and eval runs
- emit compact per-run usage telemetry to Logfire
- correct stale grounded-search and watch-lifecycle architecture docs

## Deliberate non-changes

- no Gemini/Google native search integration
- no duplicate retry layer; Perplexity and Parallel already use bounded SDK retries
- no deferred approval flow while all allowed connector tools remain read-only

## Verification

- Running backend linting...
All checks passed!
121 files already formatted
Running agent linting and type checking...
All checks passed!
15 files already formatted
All checks passed!
Running frontend linting...

> torale-frontend@0.1.0 lint
> next lint


./app/(marketing)/_components/Footer.tsx
13:13  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

./app/(marketing)/_components/Nav.tsx
34:13  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

./src/components/Logo.tsx
30:17  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element
36:17  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

./src/components/app/Sidebar.tsx
114:9  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

./src/components/dashboard/WatchList.tsx
2:10  Warning: 'Search' is defined but never used.  @typescript-eslint/no-unused-vars

./src/components/marketing/Footer.tsx
13:13  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

./src/components/marketing/Nav.tsx
38:13  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
- Running backend unit tests...
============================= test session starts ==============================
platform darwin -- Python 3.13.0, pytest-9.0.3, pluggy-1.6.0 -- /Users/prass/development/projects/torale/backend/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/prass/development/projects/torale/backend
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0, cov-7.0.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 252 items

tests/test_activities.py::TestPersistExecutionResult::test_writes_to_both_tables PASSED [  0%]
tests/test_activities.py::TestPersistExecutionResult::test_field_mapping PASSED [  0%]
tests/test_activities.py::TestFetchRecentExecutions::test_returns_structured_output PASSED [  1%]
tests/test_activities.py::TestFetchRecentExecutions::test_preserves_long_evidence PASSED [  1%]
tests/test_activities.py::TestFetchRecentExecutions::test_db_failure_returns_empty PASSED [  1%]
tests/test_activities.py::TestExecutionRecordFromDbRow::test_malformed_result_json PASSED [  2%]
tests/test_activities.py::TestExecutionRecordFromDbRow::test_malformed_grounding_sources_json PASSED [  2%]
tests/test_activities.py::TestExecutionRecordFromDbRow::test_source_missing_url_key PASSED [  3%]
tests/test_activities.py::TestExecutionRecordFromDbRow::test_result_is_none PASSED [  3%]
tests/test_activities.py::TestExecutionRecordFromDbRow::test_result_as_pre_parsed_dict PASSED [  3%]
tests/test_activities.py::TestExecutionRecordFromDbRow::test_sources_as_plain_string_list PASSED [  4%]
tests/test_activities.py::TestFormatExecutionHistory::test_empty_list_returns_empty_string PASSED [  4%]
tests/test_activities.py::TestFormatExecutionHistory::test_single_record_with_all_fields PASSED [  5%]
tests/test_activities.py::TestFormatExecutionHistory::test_empty_optional_fields_omitted PASSED [  5%]
tests/test_admin_endpoints.py::TestAdminUpdateTaskState::test_valid_transitions[pause] PASSED [  5%]
tests/test_admin_endpoints.py::TestAdminUpdateTaskState::test_valid_transitions[resume] PASSED [  6%]
tests/test_admin_endpoints.py::TestAdminUpdateTaskState::test_valid_transitions[complete] PASSED [  6%]
tests/test_admin_endpoints.py::TestAdminUpdateTaskState::test_valid_transitions[reactivate] PASSED [  7%]
tests/test_admin_endpoints.py::TestAdminUpdateTaskState::test_invalid_transitions_return_400[paused_to_completed] PASSED [  7%]
tests/test_admin_endpoints.py::TestAdminUpdateTaskState::test_invalid_transitions_return_400[completed_to_paused] PASSED [  7%]
tests/test_admin_endpoints.py::TestAdminUpdateTaskState::test_task_not_found_returns_404 PASSED [  8%]
tests/test_admin_endpoints.py::TestAdminUpdateTaskState::test_resume_includes_task_name PASSED [  8%]
tests/test_admin_endpoints.py::TestAdminUpdateTaskState::test_missing_task_name_returns_400 PASSED [  9%]
tests/test_admin_endpoints.py::TestAdminUpdateTaskState::test_scheduler_error_returns_500 PASSED [  9%]
tests/test_admin_endpoints.py::TestAdminUpdateTaskState::test_next_run_preserved_when_resuming PASSED [  9%]
tests/test_admin_endpoints.py::TestAdminUpdateTaskState::test_next_run_defaults_when_missing PASSED [ 10%]
tests/test_admin_endpoints.py::TestAdminUpdateTaskState::test_pause_does_not_require_next_run PASSED [ 10%]
tests/test_admin_endpoints.py::TestAdminUpdateTaskState::test_error_response_format PASSED [ 11%]
tests/test_admin_endpoints.py::TestAdminResetTaskHistory::test_successful_reset_and_deletion PASSED [ 11%]
tests/test_admin_endpoints.py::TestAdminResetTaskHistory::test_reset_with_no_executions PASSED [ 11%]
tests/test_admin_endpoints.py::TestAdminResetTaskHistory::test_nonexistent_task_returns_404 PASSED [ 12%]
tests/test_admin_endpoints.py::TestAdminResetTaskHistory::test_days_parameter_in_response PASSED [ 12%]
tests/test_agent.py::TestParseAgentResponse::test_structured_data PASSED [ 13%]
tests/test_agent.py::TestParseAgentResponse::test_result_wrapper_is_unwrapped PASSED [ 13%]
tests/test_agent.py::TestParseAgentResponse::test_json_text_compatibility PASSED [ 13%]
tests/test_agent.py::TestParseAgentResponse::test_empty_response_raises[artifacts0] PASSED [ 14%]
tests/test_agent.py::TestParseAgentResponse::test_empty_response_raises[None] PASSED [ 14%]
tests/test_agent.py::TestParseAgentResponse::test_python_repr_is_no_longer_accepted PASSED [ 15%]
tests/test_agent.py::TestParseAgentResponse::test_invalid_application_shape_fails_validation PASSED [ 15%]
tests/test_agent.py::TestStreamAggregation::test_folds_artifact_and_terminal_status PASSED [ 15%]
tests/test_agent.py::TestStreamAggregation::test_event_before_initial_task_is_ignored PASSED [ 16%]
tests/test_agent.py::TestErrorHandling::test_extracts_structured_error PASSED [ 16%]
tests/test_agent.py::TestErrorHandling::test_missing_error_message PASSED [ 17%]
tests/test_agent.py::TestErrorHandling::test_non_text_error_message PASSED [ 17%]
tests/test_agent.py::TestErrorHandling::test_malformed_error_json PASSED [ 17%]
tests/test_agent.py::TestErrorHandling::test_fallback_status_raises_typed_error[429] PASSED [ 18%]
tests/test_agent.py::TestErrorHandling::test_fallback_status_raises_typed_error[503] PASSED [ 18%]
tests/test_agent.py::TestErrorHandling::test_non_fallback_status_is_runtime_error PASSED [ 19%]
tests/test_agent.py::TestCallAgent::test_completed_stream PASSED         [ 19%]
tests/test_agent.py::TestCallAgent::test_metadata_survives_protobuf_conversion PASSED [ 19%]
tests/test_agent.py::TestCallAgent::test_failed_stream PASSED            [ 20%]
tests/test_agent.py::TestCallAgent::test_transport_failure PASSED        [ 20%]
tests/test_agent.py::TestCallAgent::test_timeout PASSED                  [ 21%]
tests/test_agent.py::TestCallAgent::test_free_tier_falls_back_to_paid[429] PASSED [ 21%]
tests/test_agent.py::TestCallAgent::test_free_tier_falls_back_to_paid[503] PASSED [ 21%]
tests/test_agent.py::TestCallAgent::test_non_fallback_error_does_not_switch_tiers PASSED [ 22%]
tests/test_agent.py::TestCallAgent::test_both_tiers_failing_propagates PASSED [ 22%]
tests/test_email_verification.py::TestCanSendVerification::test_rate_limit_enforcement[first_request] PASSED [ 23%]
tests/test_email_verification.py::TestCanSendVerification::test_rate_limit_enforcement[under_limit] PASSED [ 23%]
tests/test_email_verification.py::TestCanSendVerification::test_rate_limit_enforcement[at_limit] PASSED [ 23%]
tests/test_email_verification.py::TestCreateVerification::test_creates_verification_record PASSED [ 24%]
tests/test_email_verification.py::TestCreateVerification::test_sets_expiration_15_minutes PASSED [ 24%]
tests/test_email_verification.py::TestVerifyCode::test_successful_verification PASSED [ 25%]
tests/test_email_verification.py::TestVerifyCode::test_invalid_code PASSED [ 25%]
tests/test_email_verification.py::TestVerifyCode::test_expired_code PASSED [ 25%]
tests/test_email_verification.py::TestVerifyCode::test_no_attempts_left PASSED [ 26%]
tests/test_email_verification.py::TestVerifyCode::test_verification_not_found PASSED [ 26%]
tests/test_email_verification.py::TestIsEmailVerified::test_clerk_email_always_verified PASSED [ 26%]
tests/test_email_verification.py::TestIsEmailVerified::test_verified_custom_email PASSED [ 27%]
tests/test_email_verification.py::TestIsEmailVerified::test_unverified_custom_email PASSED [ 27%]
tests/test_email_verification.py::TestCheckSpamLimits::test_allows_within_daily_limit PASSED [ 28%]
tests/test_email_verification.py::TestCheckSpamLimits::test_blocks_at_daily_limit PASSED [ 28%]
tests/test_email_verification.py::TestCheckSpamLimits::test_blocks_at_hourly_limit PASSED [ 28%]
tests/test_email_verification_endpoints.py::TestSendVerificationEmail::test_send_to_new_email PASSED [ 29%]
tests/test_email_verification_endpoints.py::TestSendVerificationEmail::test_already_verified_email PASSED [ 29%]
tests/test_email_verification_endpoints.py::TestSendVerificationEmail::test_rate_limit_exceeded PASSED [ 30%]
tests/test_email_verification_endpoints.py::TestSendVerificationEmail::test_user_name_fallback PASSED [ 30%]
tests/test_email_verification_endpoints.py::TestVerifyEmailCode::test_successful_verification PASSED [ 30%]
tests/test_email_verification_endpoints.py::TestVerifyEmailCode::test_invalid_code PASSED [ 31%]
tests/test_email_verification_endpoints.py::TestVerifyEmailCode::test_expired_code PASSED [ 31%]
tests/test_email_verification_endpoints.py::TestVerifyEmailCode::test_no_attempts_remaining PASSED [ 32%]
tests/test_email_verification_endpoints.py::TestListVerifiedEmails::test_list_only_clerk_email PASSED [ 32%]
tests/test_email_verification_endpoints.py::TestListVerifiedEmails::test_list_with_custom_emails PASSED [ 32%]
tests/test_email_verification_endpoints.py::TestListVerifiedEmails::test_deduplication PASSED [ 33%]
tests/test_email_verification_endpoints.py::TestRemoveVerifiedEmail::test_remove_custom_email PASSED [ 33%]
tests/test_email_verification_endpoints.py::TestRemoveVerifiedEmail::test_cannot_remove_clerk_email PASSED [ 34%]
tests/test_email_verification_endpoints.py::TestRemoveVerifiedEmail::test_remove_nonexistent_email PASSED [ 34%]
tests/test_errors.py::TestErrorClassification::test_classification[rate_limit] PASSED [ 34%]
tests/test_errors.py::TestErrorClassification::test_classification[timeout] PASSED [ 35%]
tests/test_errors.py::TestErrorClassification::test_classification[connection_error] PASSED [ 35%]
tests/test_errors.py::TestErrorClassification::test_classification[asyncpg_connection] PASSED [ 36%]
tests/test_errors.py::TestErrorClassification::test_classification[asyncpg_oom] PASSED [ 36%]
tests/test_errors.py::TestErrorClassification::test_classification[asyncpg_resources] PASSED [ 36%]
tests/test_errors.py::TestMessageSanitization::test_user_error_sanitized_invalid PASSED [ 37%]
tests/test_errors.py::TestMessageSanitization::test_user_error_sanitized_malformed PASSED [ 37%]
tests/test_errors.py::TestMessageSanitization::test_user_error_fallback PASSED [ 38%]
tests/test_errors.py::TestMessageSanitization::test_network_error_message PASSED [ 38%]
tests/test_feed_endpoints.py::test_get_user_feed_unit PASSED             [ 38%]
tests/test_feed_endpoints.py::test_get_public_feed_unit PASSED           [ 39%]
tests/test_job.py::TestExecute::test_no_notification_skips_notify PASSED [ 39%]
tests/test_job.py::TestExecute::test_next_run_none_schedules_fallback PASSED [ 40%]
tests/test_job.py::TestExecute::test_next_run_set_does_not_complete PASSED [ 40%]
tests/test_job.py::TestExecute::test_notification_failure_still_reschedules PASSED [ 40%]
tests/test_job.py::TestExecute::test_next_run_none_reschedules_even_if_notification_fails PASSED [ 41%]
tests/test_job.py::TestExecute::test_next_run_none_without_notification_still_reschedules PASSED [ 41%]
tests/test_job.py::TestExecute::test_reschedule_skips_task_that_is_no_longer_active PASSED [ 42%]
tests/test_job.py::TestExecute::test_reschedule_removes_job_after_concurrent_state_change PASSED [ 42%]
tests/test_job.py::TestExecute::test_agent_failure_marks_failed PASSED   [ 42%]
tests/test_job.py::TestExecute::test_double_failure_logged PASSED        [ 43%]
tests/test_job.py::TestExecute::test_dynamic_reschedule PASSED           [ 43%]
tests/test_job.py::TestExecute::test_running_transition_clears_prior_error_fields PASSED [ 44%]
tests/test_job.py::TestExecute::test_retry_path_preserves_execution_id PASSED [ 44%]
tests/test_job.py::TestExecute::test_successful_scheduled_run_does_not_forward_execution_id PASSED [ 44%]
tests/test_job.py::TestExecute::test_execute_task_job_delegates_to_execute PASSED [ 45%]
tests/test_job.py::TestExecute::test_execution_history_in_prompt PASSED  [ 45%]
tests/test_job.py::TestExecute::test_first_execution_sets_flag PASSED    [ 46%]
tests/test_job.py::TestExecute::test_first_run_no_history PASSED         [ 46%]
tests/test_manual_run_coordination.py::TestManualRunCoordination::test_prevents_concurrent_execution PASSED [ 46%]
tests/test_manual_run_coordination.py::TestManualRunCoordination::test_cancels_pending_retry_job PASSED [ 47%]
tests/test_manual_run_coordination.py::TestManualRunCoordination::test_succeeds_when_no_pending_job PASSED [ 47%]
tests/test_manual_run_coordination.py::TestManualRunCoordination::test_concurrent_manual_runs_prevented PASSED [ 48%]
tests/test_manual_run_coordination.py::TestManualRunCoordination::test_inherits_retry_count_from_last_execution PASSED [ 48%]
tests/test_manual_run_coordination.py::TestManualRunCoordination::test_force_override_stuck_execution PASSED [ 48%]
tests/test_manual_run_coordination.py::TestManualRunCoordination::test_force_false_prevents_override PASSED [ 49%]
tests/test_migrate.py::TestSyncJobsFromDatabase::test_active_task_no_job_creates_job PASSED [ 49%]
tests/test_migrate.py::TestSyncJobsFromDatabase::test_paused_task_no_job_creates_and_pauses PASSED [ 50%]
tests/test_migrate.py::TestSyncJobsFromDatabase::test_active_task_paused_job_resumes PASSED [ 50%]
tests/test_migrate.py::TestSyncJobsFromDatabase::test_paused_task_active_job_pauses PASSED [ 50%]
tests/test_migrate.py::TestSyncJobsFromDatabase::test_orphaned_job_removed PASSED [ 51%]
tests/test_migrate.py::TestSyncJobsFromDatabase::test_per_task_failure_continues PASSED [ 51%]
tests/test_migrate.py::TestSyncJobsFromDatabase::test_empty_db_no_op PASSED [ 51%]
tests/test_migrate.py::TestReapStaleExecutions::test_stale_executions_marked_failed PASSED [ 52%]
tests/test_migrate.py::TestReapStaleExecutions::test_no_stale_no_op PASSED [ 52%]
tests/test_novu_service.py::TestFormatConfidence::test_format[None-None] PASSED [ 53%]
tests/test_novu_service.py::TestFormatConfidence::test_format[0-0%] PASSED [ 53%]
tests/test_novu_service.py::TestFormatConfidence::test_format[50-50%] PASSED [ 53%]
tests/test_novu_service.py::TestFormatConfidence::test_format[95-95%] PASSED [ 54%]
tests/test_novu_service.py::TestFormatConfidence::test_format[100-100%] PASSED [ 54%]
tests/test_novu_service.py::TestTaskUrl::test_builds_canonical_frontend_task_url PASSED [ 55%]
tests/test_novu_service.py::TestTaskUrl::test_url_encodes_task_id PASSED [ 55%]
tests/test_novu_service.py::TestTaskUrl::test_condition_met_payload_includes_task_url PASSED [ 55%]
tests/test_prompt_sanitizer.py::TestPromptSanitizer::test_basic_wrapping PASSED [ 56%]
tests/test_prompt_sanitizer.py::TestPromptSanitizer::test_wrapping_with_note PASSED [ 56%]
tests/test_prompt_sanitizer.py::TestPromptSanitizer::test_content_with_injection_attempt PASSED [ 57%]
tests/test_prompt_sanitizer.py::TestPromptSanitizer::test_content_with_fake_closing_tag PASSED [ 57%]
tests/test_retry_execution_id.py::test_schedule_next_run_passes_execution_id PASSED [ 57%]
tests/test_retry_execution_id.py::test_execute_task_job_accepts_execution_id PASSED [ 58%]
tests/test_retry_execution_id.py::test_execute_task_job_defaults_to_none PASSED [ 58%]
tests/test_scheduler.py::TestMakeJobStoreUrl::test_converts_to_psycopg2[postgresql+asyncpg://user:pass@host:5432/db-postgresql+psycopg2://user:pass@host:5432/db] PASSED [ 59%]
tests/test_scheduler.py::TestMakeJobStoreUrl::test_converts_to_psycopg2[postgres://user:pass@host:5432/db-postgresql+psycopg2://user:pass@host:5432/db] PASSED [ 59%]
tests/test_scheduler.py::TestMakeJobStoreUrl::test_converts_to_psycopg2[postgresql://user:pass@host:5432/db-postgresql+psycopg2://user:pass@host:5432/db] PASSED [ 59%]
tests/test_sdk_integration.py::TestSDKBasicOperations::test_create_task_minimal SKIPPED [ 60%]
tests/test_sdk_integration.py::TestSDKBasicOperations::test_create_task_with_webhook SKIPPED [ 60%]
tests/test_sdk_integration.py::TestSDKBasicOperations::test_create_task_with_email SKIPPED [ 61%]
tests/test_sdk_integration.py::TestSDKBasicOperations::test_create_task_with_multiple_notification_types SKIPPED [ 61%]
tests/test_sdk_integration.py::TestSDKBasicOperations::test_list_tasks SKIPPED [ 61%]
tests/test_sdk_integration.py::TestSDKBasicOperations::test_list_tasks_active_filter SKIPPED [ 62%]
tests/test_sdk_integration.py::TestSDKBasicOperations::test_get_task SKIPPED [ 62%]
tests/test_sdk_integration.py::TestSDKBasicOperations::test_update_task_name SKIPPED [ 63%]
tests/test_sdk_integration.py::TestSDKBasicOperations::test_update_task_schedule SKIPPED [ 63%]
tests/test_sdk_integration.py::TestSDKBasicOperations::test_update_task_state SKIPPED [ 63%]
tests/test_sdk_integration.py::TestSDKBasicOperations::test_delete_task SKIPPED [ 64%]
tests/test_sdk_integration.py::TestSDKExecution::test_execute_task SKIPPED [ 64%]
tests/test_sdk_integration.py::TestSDKExecution::test_get_executions SKIPPED [ 65%]
tests/test_sdk_integration.py::TestSDKExecution::test_get_executions_with_limit SKIPPED [ 65%]
tests/test_sdk_integration.py::TestSDKExecution::test_get_notifications SKIPPED [ 65%]
tests/test_sdk_integration.py::TestSDKValidation::test_duplicate_webhook_notifications_rejected SKIPPED [ 66%]
tests/test_sdk_integration.py::TestSDKValidation::test_duplicate_email_notifications_rejected SKIPPED [ 66%]
tests/test_sdk_integration.py::TestSDKValidation::test_invalid_email_format_rejected SKIPPED [ 67%]
tests/test_sdk_integration.py::TestSDKValidation::test_http_webhook_rejected SKIPPED [ 67%]
tests/test_sdk_integration.py::TestSDKValidation::test_get_nonexistent_task_raises_not_found SKIPPED [ 67%]
tests/test_sdk_integration.py::TestSDKValidation::test_delete_nonexistent_task_raises_not_found SKIPPED [ 68%]
tests/test_sdk_integration.py::TestSDKValidation::test_execute_nonexistent_task_raises_not_found SKIPPED [ 68%]
tests/test_sdk_integration.py::TestSDKContextManager::test_context_manager_creates_task SKIPPED [ 69%]
tests/test_sdk_integration.py::TestSDKEdgeCases::test_create_task_with_empty_notifications_list SKIPPED [ 69%]
tests/test_sdk_integration.py::TestSDKEdgeCases::test_create_task_with_custom_schedule SKIPPED [ 69%]
tests/test_sdk_integration.py::TestSDKEdgeCases::test_list_tasks_when_empty SKIPPED [ 70%]
tests/test_sdk_integration.py::TestSDKWebhooks::test_get_webhook_config SKIPPED [ 70%]
tests/test_sdk_integration.py::TestSDKWebhooks::test_update_webhook_config SKIPPED [ 71%]
tests/test_sdk_integration.py::TestSDKWebhooks::test_disable_webhook_config SKIPPED [ 71%]
tests/test_sdk_integration.py::TestSDKWebhooks::test_task_creation_with_webhook_notification SKIPPED [ 71%]
tests/test_shareable_tasks.py::TestTaskVisibilityToggle::test_make_task_public PASSED [ 72%]
tests/test_shareable_tasks.py::TestTaskVisibilityToggle::test_make_task_private PASSED [ 72%]
tests/test_shareable_tasks.py::TestPublicTaskAccess::test_get_public_task_unauthenticated PASSED [ 73%]
tests/test_shareable_tasks.py::TestPublicTaskAccess::test_get_private_task_unauthenticated PASSED [ 73%]
tests/test_shareable_tasks.py::TestPublicTaskAccess::test_get_own_private_task_authenticated PASSED [ 73%]
tests/test_shareable_tasks.py::TestTaskForking::test_fork_public_task PASSED [ 74%]
tests/test_shareable_tasks.py::TestTaskForking::test_fork_private_task_fails PASSED [ 74%]
tests/test_shareable_tasks.py::TestTaskForking::test_fork_own_task_succeeds PASSED [ 75%]
tests/test_shareable_tasks.py::TestTaskForking::test_fork_uses_default_name PASSED [ 75%]
tests/test_shareable_tasks.py::TestTaskForking::test_fork_scrubs_sensitive_fields PASSED [ 75%]
tests/test_sitemap_host_discrimination.py::TestApiHostDoesNotLeakSeoEndpoints::test_robots_on_api_host_is_blanket_disallow PASSED [ 76%]
tests/test_sitemap_host_discrimination.py::TestApiHostDoesNotLeakSeoEndpoints::test_sitemap_not_registered_on_backend PASSED [ 76%]
tests/test_sitemap_host_discrimination.py::TestApiHostDoesNotLeakSeoEndpoints::test_changelog_rss_on_api_host_returns_404 PASSED [ 76%]
tests/test_sitemap_host_discrimination.py::TestMarketingHostStillServes::test_robots_on_marketing_host_lists_sitemap PASSED [ 77%]
tests/test_task_service.py::TestTaskService::test_valid_transitions[active-paused-_pause_job-job_return0] PASSED [ 77%]
tests/test_task_service.py::TestTaskService::test_valid_transitions[active-completed-_remove_job-job_return1] PASSED [ 78%]
tests/test_task_service.py::TestTaskService::test_valid_transitions[paused-active-_add_or_resume_job-job_return2] PASSED [ 78%]
tests/test_task_service.py::TestTaskService::test_valid_transitions[completed-active-_add_or_resume_job-job_return3] PASSED [ 78%]
tests/test_task_service.py::TestTaskService::test_invalid_transitions[paused-completed] PASSED [ 79%]
tests/test_task_service.py::TestTaskService::test_invalid_transitions[completed-paused] PASSED [ 79%]
tests/test_task_service.py::TestTaskService::test_same_state_transition_is_noop PASSED [ 80%]
tests/test_task_service.py::TestTaskService::test_rollback_on_scheduler_error PASSED [ 80%]
tests/test_task_service.py::TestTaskService::test_race_condition_concurrent_state_change PASSED [ 80%]
tests/test_task_service.py::TestTaskService::test_db_parsing_error PASSED [ 81%]
tests/test_user_repository.py::TestUserRepositoryUpdateOperations::test_update_user_no_changes PASSED [ 81%]
tests/test_user_repository.py::TestUserRepositoryWebhookOperations::test_get_webhook_config PASSED [ 82%]
tests/test_user_repository.py::TestUserRepositoryWebhookOperations::test_get_webhook_config_no_url PASSED [ 82%]
tests/test_user_repository.py::TestUserRepositoryWebhookOperations::test_update_webhook_config PASSED [ 82%]
tests/test_views.py::TestIncrementView::test_noop_when_redis_not_connected PASSED [ 83%]
tests/test_views.py::TestIncrementView::test_calls_hincrby PASSED        [ 83%]
tests/test_views.py::TestIncrementView::test_swallows_redis_error PASSED [ 84%]
tests/test_views.py::TestFlushViewsToPostgres::test_noop_when_redis_not_connected PASSED [ 84%]
tests/test_views.py::TestFlushViewsToPostgres::test_noop_when_no_views PASSED [ 84%]
tests/test_views.py::TestFlushViewsToPostgres::test_flushes_counts_to_postgres PASSED [ 85%]
tests/test_views.py::TestFlushViewsToPostgres::test_recovers_stale_processing_key PASSED [ 85%]
tests/test_views.py::TestFlushViewsToPostgres::test_skips_zero_counts PASSED [ 86%]
tests/test_views.py::TestFlushViewsToPostgres::test_db_failure_preserves_processing_key PASSED [ 86%]
tests/test_views.py::TestRedisClient::test_connect_noop_without_host PASSED [ 86%]
tests/test_views.py::TestRedisClient::test_connect_noop_when_already_connected PASSED [ 87%]
tests/test_views.py::TestRedisClient::test_connect_failure_sets_client_none PASSED [ 87%]
tests/test_views.py::TestRedisClient::test_disconnect_closes_and_clears PASSED [ 88%]
tests/test_views.py::TestRedisClient::test_disconnect_noop_when_not_connected PASSED [ 88%]
tests/test_webhook.py::TestWebhookSignature::test_generate_secret PASSED [ 88%]
tests/test_webhook.py::TestWebhookSignature::test_different_secrets PASSED [ 89%]
tests/test_webhook.py::TestWebhookSignature::test_sign_format_and_hmac_sha256 PASSED [ 89%]
tests/test_webhook.py::TestWebhookSignature::test_verify_valid_signature PASSED [ 90%]
tests/test_webhook.py::TestWebhookSignature::test_verify_invalid_signature PASSED [ 90%]
tests/test_webhook.py::TestWebhookSignature::test_verify_malformed_signature PASSED [ 90%]
tests/test_webhook.py::TestWebhookSignature::test_verify_expired_timestamp PASSED [ 91%]
tests/test_webhook.py::TestWebhookSignature::test_verify_within_tolerance PASSED [ 91%]
tests/test_webhook.py::TestBuildWebhookPayload::test_payload_structure PASSED [ 92%]
tests/test_webhook.py::TestBuildWebhookPayload::test_payload_data_fields PASSED [ 92%]
tests/test_webhook.py::TestWebhookDeliveryService::test_successful_delivery PASSED [ 92%]
tests/test_webhook.py::TestWebhookDeliveryService::test_failed_delivery_retries PASSED [ 93%]
tests/test_webhook.py::TestWebhookDeliveryService::test_delivery_timeout PASSED [ 93%]
tests/test_webhook.py::TestWebhookDeliveryService::test_delivery_includes_headers PASSED [ 94%]
tests/test_webhook_endpoints.py::TestGetUserWebhookConfig::test_get_enabled_config PASSED [ 94%]
tests/test_webhook_endpoints.py::TestGetUserWebhookConfig::test_get_disabled_config PASSED [ 94%]
tests/test_webhook_endpoints.py::TestGetUserWebhookConfig::test_get_no_config PASSED [ 95%]
tests/test_webhook_endpoints.py::TestUpdateUserWebhookConfig::test_enable_webhook_first_time PASSED [ 95%]
tests/test_webhook_endpoints.py::TestUpdateUserWebhookConfig::test_enable_webhook_with_existing_secret PASSED [ 96%]
tests/test_webhook_endpoints.py::TestUpdateUserWebhookConfig::test_disable_webhook PASSED [ 96%]
tests/test_webhook_endpoints.py::TestUpdateUserWebhookConfig::test_update_webhook_url PASSED [ 96%]
tests/test_webhook_endpoints.py::TestTestWebhook::test_successful_test_delivery PASSED [ 97%]
tests/test_webhook_endpoints.py::TestTestWebhook::test_failed_test_delivery PASSED [ 97%]
tests/test_webhook_endpoints.py::TestTestWebhook::test_test_webhook_payload_structure PASSED [ 98%]
tests/test_webhook_endpoints.py::TestListWebhookDeliveries::test_list_all_user_deliveries PASSED [ 98%]
tests/test_webhook_endpoints.py::TestListWebhookDeliveries::test_list_deliveries_for_specific_task PASSED [ 98%]
tests/test_webhook_endpoints.py::TestListWebhookDeliveries::test_list_deliveries_task_not_found PASSED [ 99%]
tests/test_webhook_endpoints.py::TestListWebhookDeliveries::test_list_deliveries_respects_limit PASSED [ 99%]
tests/test_webhook_endpoints.py::TestListWebhookDeliveries::test_list_deliveries_empty_result PASSED [100%]

=============================== warnings summary ===============================
src/webwhen/core/config.py:114
  /Users/prass/development/projects/torale/backend/src/webwhen/core/config.py:114: DeprecationWarning: Environment variable 'TORALE_NOAUTH_EMAIL' is deprecated, use 'WEBWHEN_NOAUTH_EMAIL' instead. The torale-prefixed env vars will be removed in a future release.
    _warn_on_legacy_torale_env()

.venv/lib/python3.13/site-packages/pydantic/_internal/_config.py:386
  /Users/prass/development/projects/torale/backend/.venv/lib/python3.13/site-packages/pydantic/_internal/_config.py:386: UserWarning: Valid config keys have changed in V2:
  * 'fields' has been removed
    warnings.warn(message, UserWarning)

tests/test_email_verification.py::TestCanSendVerification::test_rate_limit_enforcement[first_request]
tests/test_email_verification.py::TestCanSendVerification::test_rate_limit_enforcement[under_limit]
tests/test_email_verification.py::TestCanSendVerification::test_rate_limit_enforcement[at_limit]
tests/test_email_verification.py::TestCreateVerification::test_creates_verification_record
tests/test_email_verification.py::TestCreateVerification::test_sets_expiration_15_minutes
  /Users/prass/development/projects/torale/backend/src/webwhen/notifications/email.py:30: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    hour_ago = datetime.utcnow() - timedelta(minutes=60)

tests/test_email_verification.py::TestCreateVerification::test_creates_verification_record
tests/test_email_verification.py::TestCreateVerification::test_sets_expiration_15_minutes
  /Users/prass/development/projects/torale/backend/src/webwhen/notifications/email.py:69: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    expires_at = datetime.utcnow() + timedelta(

tests/test_email_verification.py::TestVerifyCode::test_successful_verification
tests/test_email_verification.py::TestVerifyCode::test_invalid_code
tests/test_email_verification.py::TestVerifyCode::test_expired_code
tests/test_email_verification.py::TestVerifyCode::test_no_attempts_left
  /Users/prass/development/projects/torale/backend/tests/test_email_verification.py:27: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    "expires_at": datetime.utcnow() + expires_delta,

tests/test_email_verification.py::TestVerifyCode::test_successful_verification
tests/test_email_verification.py::TestVerifyCode::test_invalid_code
tests/test_email_verification.py::TestVerifyCode::test_expired_code
tests/test_email_verification.py::TestVerifyCode::test_no_attempts_left
  /Users/prass/development/projects/torale/backend/src/webwhen/notifications/email.py:113: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    if datetime.utcnow() > record["expires_at"]:

tests/test_email_verification.py::TestCheckSpamLimits::test_allows_within_daily_limit
tests/test_email_verification.py::TestCheckSpamLimits::test_blocks_at_daily_limit
tests/test_email_verification.py::TestCheckSpamLimits::test_blocks_at_hourly_limit
  /Users/prass/development/projects/torale/backend/src/webwhen/notifications/email.py:202: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    day_ago = datetime.utcnow() - timedelta(days=1)

tests/test_email_verification.py::TestCheckSpamLimits::test_allows_within_daily_limit
tests/test_email_verification.py::TestCheckSpamLimits::test_blocks_at_hourly_limit
  /Users/prass/development/projects/torale/backend/src/webwhen/notifications/email.py:216: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    hour_ago = datetime.utcnow() - timedelta(hours=1)

tests/test_webhook_endpoints.py::TestTestWebhook::test_successful_test_delivery
tests/test_webhook_endpoints.py::TestTestWebhook::test_failed_test_delivery
tests/test_webhook_endpoints.py::TestTestWebhook::test_test_webhook_payload_structure
  /Users/prass/development/projects/torale/backend/src/webwhen/api/routers/webhooks.py:115: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    "completed_at": datetime.utcnow().isoformat(),

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================= 222 passed, 30 skipped, 25 warnings in 2.58s =================
Running agent unit and protocol tests...
============================= test session starts ==============================
platform darwin -- Python 3.13.0, pytest-9.0.3, pluggy-1.6.0 -- /Users/prass/development/projects/torale/torale-agent/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/prass/development/projects/torale/torale-agent
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.4.0, logfire-4.22.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 27 items

tests/test_evals.py::test_search_tool_evaluator_uses_production_activity PASSED [  3%]
tests/test_evals.py::test_notification_decision_matches_reviewed_ground_truth PASSED [  7%]
tests/test_evals.py::test_notification_decision_catches_false_positive PASSED [ 11%]
tests/test_evals.py::test_empty_notification_matches_production_no_trigger_semantics PASSED [ 14%]
tests/test_evals.py::test_static_dataset_loads_decision_regressions PASSED [ 18%]
tests/test_evals.py::test_agent_can_override_gemini_thinking_level PASSED [ 22%]
tests/test_evals.py::test_agent_reads_gemini_thinking_level_from_environment PASSED [ 25%]
tests/test_evals.py::test_agent_defaults_to_minimal_gemini_thinking PASSED [ 29%]
tests/test_evals.py::test_other_gemini_models_keep_high_thinking_default PASSED [ 33%]
tests/test_evals.py::test_always_on_gemini_model_rejects_minimal_thinking PASSED [ 37%]
tests/test_evals.py::test_non_thinking_model_rejects_thinking_override PASSED [ 40%]
tests/test_evals.py::test_openai_compatible_models_use_native_structured_output PASSED [ 44%]
tests/test_evals.py::test_openai_compatible_models_default_to_tool_structured_output PASSED [ 48%]
tests/test_evals.py::test_evidence_tools_expose_typed_return_schemas PASSED [ 51%]
tests/test_evals.py::test_monitoring_usage_policy_bounds_runaway_agent_loops PASSED [ 55%]
tests/test_evals.py::test_model_output_mode_can_be_read_from_environment PASSED [ 59%]
tests/test_evals.py::test_fetch_assertion_is_scoped_to_webpage_cases PASSED [ 62%]
tests/test_server.py::test_success_emits_initial_task_before_updates PASSED [ 66%]
tests/test_server.py::test_missing_metadata_emits_final_failed_status PASSED [ 70%]
tests/test_server.py::test_model_http_error_preserves_fallback_details[429] PASSED [ 74%]
tests/test_server.py::test_model_http_error_preserves_fallback_details[503] PASSED [ 77%]
tests/test_server.py::test_cancel_is_terminal PASSED                     [ 81%]
tests/test_server.py::test_no_mcp_metadata_allocates_nothing PASSED      [ 85%]
tests/test_server.py::test_mcp_entries_are_validated_and_configured PASSED [ 88%]
tests/test_server.py::test_per_run_toolset_lifecycle_closes_on_success_and_failure[False] PASSED [ 92%]
tests/test_server.py::test_per_run_toolset_lifecycle_closes_on_success_and_failure[True] PASSED [ 96%]
tests/test_server.py::test_real_client_and_server_stream_structured_result PASSED [100%]

=============================== warnings summary ===============================
tests/test_server.py::test_real_client_and_server_stream_structured_result
tests/test_server.py::test_real_client_and_server_stream_structured_result
tests/test_server.py::test_real_client_and_server_stream_structured_result
tests/test_server.py::test_real_client_and_server_stream_structured_result
  /Users/prass/development/projects/torale/torale-agent/.venv/lib/python3.13/site-packages/a2a/utils/proto_utils.py:303: DeprecationWarning: label() is deprecated. Use is_required() or is_repeated() instead.
    errors = _validate_proto_required_fields_internal(msg)

tests/test_server.py::test_real_client_and_server_stream_structured_result
tests/test_server.py::test_real_client_and_server_stream_structured_result
tests/test_server.py::test_real_client_and_server_stream_structured_result
tests/test_server.py::test_real_client_and_server_stream_structured_result
tests/test_server.py::test_real_client_and_server_stream_structured_result
tests/test_server.py::test_real_client_and_server_stream_structured_result
tests/test_server.py::test_real_client_and_server_stream_structured_result
  /Users/prass/development/projects/torale/torale-agent/.venv/lib/python3.13/site-packages/a2a/utils/proto_utils.py:263: DeprecationWarning: label() is deprecated. Use is_required() or is_repeated() instead.
    sub_errs = _validate_proto_required_fields_internal(val)

tests/test_server.py::test_real_client_and_server_stream_structured_result
tests/test_server.py::test_real_client_and_server_stream_structured_result
  /Users/prass/development/projects/torale/torale-agent/.venv/lib/python3.13/site-packages/a2a/utils/proto_utils.py:272: DeprecationWarning: label() is deprecated. Use is_required() or is_repeated() instead.
    sub_errs = _validate_proto_required_fields_internal(item)

tests/test_server.py::test_real_client_and_server_stream_structured_result
tests/test_server.py::test_real_client_and_server_stream_structured_result
tests/test_server.py::test_real_client_and_server_stream_structured_result
tests/test_server.py::test_real_client_and_server_stream_structured_result
  /Users/prass/development/projects/torale/torale-agent/.venv/lib/python3.13/site-packages/a2a/utils/proto_utils.py:268: DeprecationWarning: label() is deprecated. Use is_required() or is_repeated() instead.
    sub_errs = _validate_proto_required_fields_internal(v)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 27 passed, 17 warnings in 1.83s ======================== (222 backend passed, 30 skipped; 27 agent/protocol passed)
- 
> webwhen-docs@1.0.0 docs:build
> vitepress build && node scripts/build-nginx-redirects.mjs


  vitepress v1.6.4

build complete in 6.96s.
Wrote 7 exact + 4 prefix rules to:
  /Users/prass/development/projects/torale/docs-site/nginx-redirects.conf
  /Users/prass/development/projects/torale/docs-site/nginx-redirects-map.conf
- live one-case Gemini 3.5 Flash-Lite minimal eval consumed the typed Parallel result, made the correct no-trigger decision, cited python.org, and emitted usage telemetry
